### PR TITLE
Fix StatsModels

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,6 @@ StatsModels = "3eaba693-59b7-5ba5-a881-562e759f1c8d"
 
 [compat]
 StatsBase = ">=0.30.0"
-StatsModels = "<0.6.0"
 
 [extras]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"

--- a/src/Survival.jl
+++ b/src/Survival.jl
@@ -6,8 +6,11 @@ using PositiveFactorizations
 using StatsBase
 using StatsModels
 
+import StatsModels: AbstractTerm, concrete_term, modelcols
+
 export
     EventTime,
+    EventTimeTerm,
     isevent,
     iscensored,
 

--- a/src/eventtimes.jl
+++ b/src/eventtimes.jl
@@ -39,3 +39,16 @@ end
 
 isevent(ev::EventTime) = ev.status
 iscensored(ev::EventTime) = !ev.status
+
+
+# Concrete term to play along StatsModels
+
+struct EventTimeTerm <: AbstractTerm
+    sym::Symbol
+end
+
+function concrete_term(t::Term, xs::AbstractVector{<:EventTime}, ::Nothing)
+    EventTimeTerm(t.sym)
+end
+
+modelcols(t::EventTimeTerm, d::NamedTuple) = d[t.sym]


### PR DESCRIPTION
Hi! This should fix #10, although it might be more elegant to proceed as @kleinschmidt  [recommended](https://github.com/JuliaStats/Survival.jl/issues/10#issuecomment-471343737) by defining the two lines of logic in StatsModels and including here only:

```julia
function concrete_term(t::Term, xs::AbstractVector{<:EventTime}, ::Nothing)
    IdentityTerm(t.sym)
end
```

@kleinschmidt: Does it matter if we dispatch on `concrete_term` rather than `schema`?