### PR TITLE
statsmodels compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: julia
 os:
   - linux
 julia:
-  - 0.7
   - 1.0
   - 1.1
   - nightly

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Survival"
 uuid = "8a913413-2070-5976-9d4c-2b364fdc2f7f"
-version = "0.1.0"
+version = "0.2.0"
 
 [deps]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"

--- a/Project.toml
+++ b/Project.toml
@@ -10,6 +10,7 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 StatsModels = "3eaba693-59b7-5ba5-a881-562e759f1c8d"
 
 [compat]
+julia = "1"
 StatsBase = ">=0.30.0"
 StatsModels = ">=0.6.0"
 

--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ StatsModels = "3eaba693-59b7-5ba5-a881-562e759f1c8d"
 
 [compat]
 StatsBase = ">=0.30.0"
-StatsModels = "<0.6.0"
+StatsModels = ">=0.6.0"
 
 [extras]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"

--- a/src/eventtimes.jl
+++ b/src/eventtimes.jl
@@ -39,3 +39,9 @@ end
 
 isevent(ev::EventTime) = ev.status
 iscensored(ev::EventTime) = !ev.status
+
+## StatsModels compatibility
+
+StatsModels.concrete_term(t::Term, xs::AbstractVector{<:EventTime}, ::Nothing) =
+    StatsModels.ContinuousTerm(t.sym, first(xs), first(xs), first(xs), first(xs))
+Base.copy(et::EventTime) = et


### PR DESCRIPTION
treat vectors of EventTimes like continuous terms.  needs JuliaStats/StatsModels.jl#106 (to just copy continuous terms instead of converting to Float64).

fixes #10 , #16 