### PR TITLE
CIF and CompetingEventTimes

### DIFF
--- a/src/Survival.jl
+++ b/src/Survival.jl
@@ -25,7 +25,16 @@ export
     nobs,
     dof,
     vcov,
-    stderror
+    stderror,
+
+    CumulativeIncidence,
+    CompetingEventTime,
+    eventtime,
+    eventstatus,
+    iseventofinterest,
+    iscompetitingevent,
+    swapeventofinterest,
+    swapcensoringevent
 
 
 abstract type AbstractEstimator end
@@ -37,5 +46,6 @@ include("kaplanmeier.jl")
 include("nelsonaalen.jl")
 include("cox.jl")
 include("optimization.jl")
+include("cuminc.jl")
 
 end # module

--- a/src/cuminc.jl
+++ b/src/cuminc.jl
@@ -1,0 +1,203 @@
+"""
+    fit(CumulativeIncidence, CompetingEventTimes)
+    fit(CumulativeIncidence, times, status, eventofinterest, censoringevent)
+
+Given a vector of times to events, a vector of indicators for the event of interest,
+and a vector of indicators for the competing event, compute the an estimate of the
+cumulative incidence of failure.
+
+The resulting `CumulativeIncidence` object has the following fields:
+
+* `times`: Distinct event times
+* `neventsofinterest`: Number of observed events of interest at each time
+* `nallevents`: Number of observed events of any kind at each time
+* `ncensor`: Number of right censorings for all events at each time
+* `natrisk`: Size of the risk set at each time
+* `estimate`: Estimate of the cumulative incidence of failure
+* `stderr`: Standard error of the estimate of the cumulative incidence of failure
+* `survival`: Estimate of the overall Kaplan-Meier survival
+* `survivalstderr`: Standard error of the estimate of the overall Kaplan-Meier survival
+
+### Formulas
+
+In the presence of competing risks, `1-KM`, where `KM` is the Kaplan-Meier estimate,
+is uninterpretable and is a biased estimate of the failure probability. The
+cumulative incidence estimator of Kalbfleisch and Prentice (1980) is a function
+of the hazards of both the event of interest and the competing event, and provides
+an unbiased estimate of the failure probability.
+
+The estimator of the cumulative incidence for event ``k`` is given by
+``
+\\hat{I}_k(t) = \\sum_{i: t_i < t} \\hat{S}(t_{i-1}) \\frac{d_{k,i}}{n_i}
+``
+where ``d_{k,i}`` are the events of interest ``k`` at time ``t_i``,
+``n_i`` are the individuals at risk at that time,
+and ``\\hat{S}(t_{i-1})`` is the usual Kaplan-Meier estimate of survival.
+
+Standard errors are computed using the Delta method.
+
+### References
+
+* Kalbfleisch, J. D., and Prentice, R. L. (1980). *The Statistical Analysis of
+  Failure Time Data*. New York, NY: John Wiley.
+"""
+struct CumulativeIncidence{T<:Real} <: NonparametricEstimator
+    times::Vector{T}
+    neventsofinterest::Vector{Int}
+    nallevents::Vector{Int}
+    ncensor::Vector{Int}
+    natrisk::Vector{Int}
+    estimate::Vector{Float64}
+    stderr::Vector{Float64}
+    survival::Vector{Float64} # overall KM estimator (needed for CIF, so might as well return it)
+    survivalstderr::Vector{Float64} # se of overall KM estimator
+end
+
+
+
+
+estimator_start(::Type{CumulativeIncidence}) = 0.0  # Estimator starting point
+
+estimator_update(::Type{CumulativeIncidence}, es, d, n, S) = es + S * (d / n) # Estimator update rule
+
+stderr_start(::Type{CumulativeIncidence}) = 0.0
+
+
+# Delta method variance formula (as opposed to Aalen counting process method)
+function stderr_update(::Type{CumulativeIncidence}, es, dᵢ, dₐ, nₐ, surv, gw, vartmp1, vartmp2)
+    nextvartmp1 = vartmp1 + es * dₐ / (nₐ * (nₐ - dₐ)) + surv * dᵢ / nₐ^2
+    nextvartmp2 = vartmp2 + es^2 * dₐ / (nₐ * (nₐ - dₐ)) + surv^2 * (nₐ - dᵢ) * dᵢ / nₐ^3 + 2 * es * surv * dᵢ / nₐ^2
+    vares = es^2 * gw - 2 * es * nextvartmp1 + nextvartmp2 
+    return (vares,nextvartmp1,nextvartmp2)
+end
+
+
+
+# formula ref: Coviello and Boggess (2004), stcompet, The Stata Journal
+# expand the variance formula into current values and sums of past values
+
+# subscript "a" means any or all, while "i" means event of interest
+
+function _estimator(::Type{CumulativeIncidence}, tte::AbstractVector{CompetingEventTime{T,S}}) where {T,S}
+    nobs = length(tte)
+    dᵢ = 0                   # Number of observed events of interest at time t
+    dₐ = 0                   # Number of all observed events at time t
+    cₐ = 0                   # Number of censored events at time t
+    nₐ = nobs                # Number remaining at risk at time t
+    es = estimator_start(CumulativeIncidence)  # Estimator starting point
+    vares = stderr_start(CumulativeIncidence)     # Standard Error starting point
+    surv = estimator_start(KaplanMeier)  # Survival Estimator starting point 
+    gw = stderr_start(KaplanMeier)     # Standard Error starting point for Greenwood's portion
+
+    times = T[]              # The set of unique event times
+    neventsofinterest = Int[]  # Total observed events of interest at each time
+    nallevents = Int[]          # Total observed events at each time
+    ncensor = Int[]          # Total censored events at each time
+    natrisk = Int[]          # Number at risk at each time
+    estimator = Float64[]    # Estimates
+    stderr = Float64[]       # Pointwise standard errors
+    survival = Float64[]       # Overall survival function estimate
+    survivalstderr = Float64[]       # Pointwise standard error of Overall survival function estimate
+
+    t_prev = zero(T)
+    vartmp1 = 0.0
+    vartmp2 = 0.0
+
+    @inbounds for i = 1:nobs
+        tte_i = tte[i]
+        t = tte_i.time
+        s = iseventofinterest(tte_i)
+        a = isevent(tte_i)
+        # Aggregate over tied times
+        if t == t_prev
+            dᵢ += s
+            cₐ += !a
+            dₐ += a
+            continue
+        elseif !iszero(t_prev)
+            gw = stderr_update(KaplanMeier, gw, dₐ, nₐ)
+            es = estimator_update(CumulativeIncidence, es, dᵢ, nₐ, surv)
+            vares,vartmp1,vartmp2 = stderr_update(CumulativeIncidence, es, dᵢ, dₐ, nₐ, surv, gw, vartmp1, vartmp2)
+            surv = estimator_update(KaplanMeier, surv, dₐ, nₐ)
+            
+            push!(times, t_prev)
+            push!(neventsofinterest, dᵢ)
+            push!(nallevents, dₐ)
+            push!(ncensor, cₐ)
+            push!(natrisk, nₐ)
+            push!(estimator, es)
+            push!(stderr, sqrt(vares))
+            push!(survival, surv)
+            push!(survivalstderr, surv*sqrt(gw))
+        end
+        nₐ -= dₐ + cₐ
+        cₐ = !a
+        dₐ = a
+        dᵢ = s
+        t_prev = t
+    end
+
+    # We need to do this one more time to capture the last time
+    # since everything in the loop is lagged
+    push!(times, t_prev)
+    push!(neventsofinterest, dᵢ)
+    push!(nallevents, dₐ)
+    push!(ncensor, cₐ)
+    push!(natrisk, nₐ)
+    push!(estimator, es)
+    push!(stderr, sqrt(vares))
+    push!(survival, surv)
+    push!(survivalstderr, surv*sqrt(gw))
+
+    return CumulativeIncidence{T}(times, neventsofinterest, nallevents, ncensor, natrisk, estimator, stderr, survival, survivalstderr)
+end
+
+
+function StatsBase.fit(::Type{CumulativeIncidence},tte::AbstractVector{CompetingEventTime{T,S}}) where {T<:Real,S}
+    nobs = length(tte)
+    if nobs == 0
+        throw(ArgumentError("The sample must be nonempty."))
+    end
+
+    sortedevents = sort(tte)
+
+    return _estimator(CumulativeIncidence, sortedevents)
+end
+
+
+
+
+# helper function for people too lazy to create CompetingEventTime objects
+function StatsBase.fit(::Type{CumulativeIncidence},
+                       times::AbstractVector{T},
+                       status::AbstractVector{S},
+                       eventofinterest::S,censoringevent::S) where {T<:Real,S}
+    nobs = length(times)
+    if !(nobs == length(status))
+        throw(DimensionMismatch("The input vectors must have the same length"))
+    end
+    if nobs == 0
+        throw(ArgumentError("the sample must be nonempty"))
+    end
+    tte = CompetingEventTime.(times,status,eventofinterest,censoringevent)
+    return StatsBase.fit(CumulativeIncidence,tte)
+end
+
+
+"""
+    confint(km::CumulativeIncidence, α=0.05)
+
+Compute the pointwise log-log transformed confidence intervals for the 
+cumulative incidence function as a vector of tuples.
+"""
+function StatsBase.confint(km::CumulativeIncidence, α::Float64=0.05)
+    q = quantile(Normal(), 1 - α/2)
+    return map(km.estimate, km.stderr) do es, se
+        a = q * se / (es *log(es))
+        es^exp(-a), es^exp(a)
+    end
+end
+
+
+
+

--- a/src/eventtimes.jl
+++ b/src/eventtimes.jl
@@ -37,11 +37,111 @@ end
 
 ## New functions
 
-isevent(ev::EventTime) = ev.status
 iscensored(ev::EventTime) = !ev.status
+isevent(ev::EventTime) = ev.status
+
 
 ## StatsModels compatibility
 
 StatsModels.concrete_term(t::Term, xs::AbstractVector{<:EventTime}, ::Nothing) =
     StatsModels.ContinuousTerm(t.sym, first(xs), first(xs), first(xs), first(xs))
 Base.copy(et::EventTime) = et
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+############## COMPETING EVENTS
+
+## Type constructors
+
+"""
+`CompetingEventTime{T,S}(time, status, eventofinterest, censoringevent)`
+
+Immutable object containing the real-valued time to an event as well as a status variable
+indicating whether the time corresponds to the event of interest, a competing event, or censoring.
+It also stores the values of `status` that correspond to the event of interest and censored observations.
+
+By default, `status` is an integer valued variable with `1` being the event of interest and `0` being censored values.
+When using the default values, it is possible to supply only `time` and `status`.
+When status can take on other types like `String` or `Symbol`, the full constructor is required.
+
+```
+CompetingEventTime(1.7,1,1,0)
+CompetingEventTime(1.7,1)   # same as above
+CompetingEventTime(1.7,1; eventofinterest=5, censoringevent=-1)   # Int keyword args supported
+CompetingEventTime(1.2,"death","relapse","censor")  # full constructor
+CompetingEventTime(1.2,:death,:relapse,:censor) 
+```
+"""
+struct CompetingEventTime{T<:Real,S}
+    time::T
+    status::S
+    eventofinterest::S
+    censoringevent::S
+end
+
+# CompetingEventTime(time::T) where {T<:Real} = CompetingEventTime{T,Int64}(time, 1, 1, 0)
+# helper function for probably the more common case (status being Int)
+# for all other cases, require user to use full 4 arg constructor
+CompetingEventTime(time::T,status::S=1; eventofinterest::S=one(S), censoringevent::S=zero(S)) where {T<:Real,S<:Int} = CompetingEventTime{T,S}(time, status, eventofinterest, censoringevent)
+
+
+## New functions
+eventtime(ev::CompetingEventTime) = ev.time
+eventstatus(ev::CompetingEventTime) = ev.status
+iscensored(ev::CompetingEventTime) = ev.status == ev.censoringevent
+iseventofinterest(ev::CompetingEventTime) = ev.status == ev.eventofinterest
+isevent(ev::CompetingEventTime) = !iscensored(ev)
+iscompetitingevent(ev::CompetingEventTime) = !iscensored(ev) && !iseventofinterest(ev)
+
+eventtype(::CompetingEventTime{T,S}) where {T,S} = S
+
+## Overloaded Base functions
+
+Base.eltype(::CompetingEventTime{T,S}) where {T,S} = T
+function Base.show(io::IO, ev::CompetingEventTime{T,S}) where {T,S} 
+    # print(io, "CompetingEventTime{",T,",",S,"}(",ev.time, ifelse(iseventofinterest(ev), "", "+"),ifelse(iscensored(ev),"",string(" (",ev.status,")")),")")
+    printstring = string(ev.time, ifelse(iseventofinterest(ev), "", "+"))
+    if iscompetitingevent(ev)
+        printstring = string(printstring," (",ev.status,")")
+    end
+    print(io, printstring)
+end
+
+
+Base.convert(T::Type{<:Real}, ev::CompetingEventTime) = convert(T, ev.time)
+Base.convert(T::Type{CompetingEventTime}, x::Real) = CompetingEventTime(x)
+
+function Base.isless(t1::CompetingEventTime, t2::CompetingEventTime)
+    if t1.time == t2.time
+        # When two EventTimes have the same observed time, we compare the event
+        # status. Observed events compare less than censored events, since if the
+        # censored event were to occur then it would happen at or after the given
+        # time (by definition). Two tied events are considered to have no proper order
+        # (all comparisons return false).
+        return isevent(t1) && iscensored(t2)
+    else
+        return isless(t1.time, t2.time)
+    end
+end
+
+
+
+swapeventofinterest(ev::CompetingEventTime{T,S},neweoi::S) where {T,S} = CompetingEventTime{T,S}(ev.time,ev.status,neweoi,ev.censoringevent)
+swapcensoringevent(ev::CompetingEventTime{T,S},newcensor::S) where {T,S} = CompetingEventTime{T,S}(ev.time,ev.status,ev.eventofinterest,newcensor)
+Base.copy(ev::CompetingEventTime) = ev
+
+## StatsModels compatibility
+# StatsModels.concrete_term(t::Term, xs::AbstractVector{<:CompetingEventTime}, ::Nothing) =
+#     StatsModels.ContinuousTerm(t.sym, first(xs), first(xs), first(xs), first(xs))


### PR DESCRIPTION
This improves upon #4. I slopped this down pretty quickly but let me say first that I did test it against `stcompet` from Stata and it gave identical results, so I've got that going for me.

I started with the `CompetingEventTime` as an extension of `EventTime`. I made it very general, which could probably also be done to `EventTime` in the same spirit. There is probably a way to mesh them together much better. I do think it is better to herd users toward these types (as opposed to always allowing them to supply lots of vectors) because it allows for easier handling within the estimators if you do this bit of "pre-organization".

The estimator computes only the CIF for the event of interest, not for all events. It is certainly possible to do all of them in a single pass, but I didn't see a quick easy way to do so and keep it flexible like it is now. The downside is that if you need the CIF for all 5 of your competing events, you need to run this estimator 5 times. The upside is that I made it pretty easy to do so by providing a `swapeventofinterest` function, so that you can quickly convert your event times and rerun the estimator. I think making it compute all of them at once could be done at a later time.

I initially tried to not add a new `_estimator` method for `CumulativeIncidence`, but it requires tracking some additional variables over time so I didn't see a way to do that in the existing framework. So, it sort of looks like the existing method but functionally it is not integrated.

I have not implemented any CI tests and some docstring cleanup is needed. Would appreciate some help polishing this up a bit.



