### PR TITLE
Tables.jl integration

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,12 +8,14 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 PositiveFactorizations = "85a6dd25-e78a-55b7-8502-1745935b8125"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 StatsModels = "3eaba693-59b7-5ba5-a881-562e759f1c8d"
+Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [compat]
 Distributions = "0.20, 0.21, 0.22, 0.23"
 PositiveFactorizations = "0.2"
 StatsBase = "0.30, 0.31, 0.32, 0.33"
 StatsModels = "0.6"
+Tables = "1"
 julia = "1"
 
 [extras]

--- a/src/Survival.jl
+++ b/src/Survival.jl
@@ -5,6 +5,7 @@ using LinearAlgebra
 using PositiveFactorizations
 using StatsBase
 using StatsModels
+using Tables
 
 export
     EventTime,
@@ -37,5 +38,6 @@ include("kaplanmeier.jl")
 include("nelsonaalen.jl")
 include("cox.jl")
 include("optimization.jl")
+include("tables.jl")
 
 end # module

--- a/src/tables.jl
+++ b/src/tables.jl
@@ -1,0 +1,11 @@
+
+
+## Tables.jl integration??
+## get it basically for free....
+Tables.istable(::Type{<:NonparametricEstimator}) = true
+Tables.columnaccess(::Type{<:NonparametricEstimator}) = true
+Tables.columns(np::T) where {T<:NonparametricEstimator} = (;Iterators.zip(propertynames(np),map(nm->getproperty(np,nm),propertynames(np)))...)
+Tables.schema(np::T) where {T<:NonparametricEstimator} = Tables.Schema(propertynames(np),eltype.(fieldtypes(typeof(np))))
+
+
+# km = fit(KaplanMeier,ev) |> DataFrame


### PR DESCRIPTION
Something I stumbled across while working on the previous PR... free Tables.jl integration! Because the existing (+CIF) nonparametric estimators return vectors of equal length, why not go one extra step and make it table friendly?

Before this PR:
```julia
julia> ev = EventTime.(rand(10),rand(Bool,10))
10-element Array{EventTime{Float64},1}:
 0.35179991680800793
 0.40759565633515504
 0.8775546088667416
 0.45056768643591116+
 0.7839147900638677
 0.5359791316287386
 0.6307186426517366
 0.7518185123916523
 0.2001353457567876
 0.0664477717088301+

julia> km = fit(KaplanMeier,ev)
KaplanMeier{Float64}([0.0664477717088301, 0.2001353457567876, 0.35179991680800793, 0.40759565633515504, 0.45056768643591116, 0.5359791316287386, 0.6307186426517366, 0.7518185123916523, 0.7839147900638677, 0.8775546088667416], [0, 1, 1, 1, 0, 1, 1, 1, 1, 1], [1, 0, 0, 0, 1, 0, 0, 0, 0, 0], [10, 9, 8, 7, 6, 5, 4, 3, 2, 1], [1.0, 0.8888888888888888, 0.7777777777777777, 0.6666666666666666, 0.6666666666666666, 0.5333333333333333, 0.4, 0.2666666666666667, 0.13333333333333336, 0.13333333333333336], [0.0, 0.11785113019775792, 0.1781741612749496, 0.23570226039551584, 0.23570226039551584, 0.32489314482696546, 0.4346134936801766, 0.5962847939999438, 0.9249624617007738, 0.9249624617007738])
```

Now with it...
```julia
julia> using DataFrames

julia> km |> DataFrame
10×6 DataFrame
│ Row │ times     │ nevents │ ncensor │ natrisk │ survival │ stderr   │
│     │ Float64   │ Int64   │ Int64   │ Int64   │ Float64  │ Float64  │
├─────┼───────────┼─────────┼─────────┼─────────┼──────────┼──────────┤
│ 1   │ 0.0664478 │ 0       │ 1       │ 10      │ 1.0      │ 0.0      │
│ 2   │ 0.200135  │ 1       │ 0       │ 9       │ 0.888889 │ 0.117851 │
│ 3   │ 0.3518    │ 1       │ 0       │ 8       │ 0.777778 │ 0.178174 │
│ 4   │ 0.407596  │ 1       │ 0       │ 7       │ 0.666667 │ 0.235702 │
│ 5   │ 0.450568  │ 0       │ 1       │ 6       │ 0.666667 │ 0.235702 │
│ 6   │ 0.535979  │ 1       │ 0       │ 5       │ 0.533333 │ 0.324893 │
│ 7   │ 0.630719  │ 1       │ 0       │ 4       │ 0.4      │ 0.434613 │
│ 8   │ 0.751819  │ 1       │ 0       │ 3       │ 0.266667 │ 0.596285 │
│ 9   │ 0.783915  │ 1       │ 0       │ 2       │ 0.133333 │ 0.924962 │
│ 10  │ 0.877555  │ 1       │ 0       │ 1       │ 0.133333 │ 0.924962 │
```

Needs tests and I guess a mention somewhere that this is possible.