### PR TITLE
ENH: Add log rank testing

### DIFF
--- a/src/Survival.jl
+++ b/src/Survival.jl
@@ -26,8 +26,9 @@ export
     nobs,
     dof,
     vcov,
-    stderror
+    stderror,
 
+	logrank_test
 
 abstract type AbstractEstimator end
 abstract type NonparametricEstimator <: AbstractEstimator end

--- a/src/kaplanmeier.jl
+++ b/src/kaplanmeier.jl
@@ -53,3 +53,292 @@ dictate whether each time is an observed event or is right censored, compute the
 Kaplan-Meier estimate of the survivor function.
 """
 StatsBase.fit(::Type{KaplanMeier}, times, status)
+
+# Calculate the number at risk in each group and total number of
+# events at the given time point 't', which may not be an event time
+# in some of the KaplanMeier fits.
+function update_km!(km::NTuple{N,KaplanMeier{T}}, t::T, natrisk::Vector,
+                    nevents::Vector) where {N,T}
+
+    natrisk .= 0
+    nevents .= 0
+    for (j,k) in enumerate(km)
+        l = searchsortedfirst(k.times, t)
+        if l > length(k.times)
+            l -= 1
+        else
+            natrisk[j] = k.natrisk[l]
+        end
+        if k.times[l] == t
+            nevents[j] = k.nevents[l]
+        end
+    end
+end
+
+"""
+    logrank_test(km) -> NamedTuple
+
+Conduct a logrank test for the null hypothesis that n population
+survival functions are equal.  The parameters here are an arbitrary
+number of fitted survival functions of type 'KaplanMeier'.
+"""
+function logrank_test(km::KaplanMeier...; method=:LogRank, psf=nothing, fh=[1., 1.])
+
+    if method == :FH && isnothing(psf)
+        error("When method is 'FH', the pooled survival function 'psf' must be provided")
+    end
+
+    # We are comparing p groups
+    p = length(km)
+
+    # All distinct times across all groups
+    tu = sort(unique(vcat([k.times for k in km]...)))
+
+    # Total events per group
+    obs = zeros(p)
+
+    # Workspace
+    natrisk, nevents, expval = zeros(p), zeros(p), zeros(p)
+
+    # The variance/covariance matrix of the estimates
+    va = zeros(p, p)
+
+    wtsum = 0.0
+    wtcount = 0.0
+
+    # Dictionary to locate the entry in psf that corresponds
+    # to each unique time.
+    psf_ix = Dict{Int,Int}()
+    if !isnothing(psf)
+        for i in eachindex(psf.times)
+            psf_ix[psf.times[i]] = i
+        end
+    end
+
+    for (i,t) in enumerate(tu)
+
+        update_km!(km, t, natrisk, nevents)
+        r = sum(natrisk)
+        d = sum(nevents)
+
+        wt = if method == :LogRank
+                1.0
+            elseif method == :WBG
+                r
+            elseif method == :TW
+                sqrt(r)
+            elseif method == :FH
+                i = psf_ix[t]
+                f = i > 1 ? psf.survival[i-1] : 1
+                f^fh[1] * (1 - f)^fh[2]
+            else
+                error("Unknown weighting method in logrank_test")
+            end
+        wtsum += wt
+        wtcount += 1
+
+        # Update the expected values
+        expval .+= d * wt .* natrisk ./ sum(natrisk)
+
+        # Update the number of events
+        obs .+= wt .* nevents
+
+        # Update the variance/covariance matrix
+        if r > 1
+            f = d*(r-d) / (r^2*(r-1))
+            for i1 in 1:p
+                va[i1, i1] += wt^2 * f * natrisk[i1] * (r - natrisk[i1])
+                for i2 in 1:i1-1
+                    u = wt^2 * f * natrisk[i1] * natrisk[i2]
+                    va[i1, i2] -= u
+                    va[i2, i1] -= u
+                end
+            end
+        end
+    end
+
+    # Normalize the weights
+    scale = wtcount ./ wtsum
+    obs .*= scale
+    expval .*= scale
+    va .*= scale.^2
+
+    # Compute the test statistic
+    od = obs - expval
+    stat = od[1:p-1]' * (va[1:p-1, 1:p-1] \ od[1:p-1])
+    dof = p - 1
+    pvalue = 1 - cdf(Chisq(dof), stat)
+
+    return (stat=stat, dof=dof, pvalue=pvalue, observed=obs, expected=expval, var=va)
+end
+
+"""
+    logrank_test(km) -> NamedTuple
+
+Conduct a logrank test for the null hypothesis that n population
+survival functions are equal using stratified data.  The parameter km
+is a vector of vectors of fitted survival functions of type
+'KaplanMeier'.  The outer index of this vector of vectors corresponds
+to distinct strata, and the inner index corresponds to groups.  The
+null hypothesis is that the population survival functions are equal
+across all groups within each stratum.
+"""
+function logrank_test(km::Vector{Vector{KaplanMeier}}; method=:LogRank,
+                      psf=fill(nothing, length(km)), fh=[1.0, 1.0])
+
+    if method == :FH && (nothing in psf)
+        error("If method is FH, the pooled survival function psf must be provided")
+    end
+
+    # Conduct a logrank test for each stratum
+    st = [logrank_test(x...; method=method, psf=ps, fh=fh) for (x, ps) in zip(km, psf)]
+    observed = sum([x.observed for x in st])
+    expected = sum([x.expected for x in st])
+    variance = sum([x.var for x in st])
+
+    # Compute the test statistic
+    od = observed - expected
+    p = size(km, 1)
+    stat = od[1:p-1]' * (variance[1:p-1, 1:p-1] \ od[1:p-1])
+    dof = p - 1
+    pvalue = 1 - cdf(Chisq(dof), stat)
+
+    return (stat=stat, dof=dof, pvalue=pvalue, observed=observed, expected=expected, var=variance)
+end
+
+# Return the indices where a new consecutive run of identival values
+# occurs in the sorted array 'v'.
+function index_splits(v)
+    jj = [i for i in 2:length(v) if v[i] != v[i-1]]
+    prepend!(jj, 1)
+    push!(jj, length(v)+1)
+    return jj
+end
+
+# Split the 'time' and 'status' vectors according to the distinct
+# values in the vector 'group', then fit a Kaplan Meier estimate of
+# the survival function for each subset of data thus obtained.  Also
+# returns the labels of the distinct groups, sorted compatibly with
+# the returned vector of KaplanMeier values.
+function make_km(time, status, group)
+
+    ii = sortperm(group)
+    time = time[ii]
+    status = status[ii]
+    group = group[ii]
+
+    jj = index_splits(group)
+    km = KaplanMeier[]
+    for j in 1:length(jj)-1
+        i1, i2 = jj[j], jj[j+1]
+        k = fit(KaplanMeier, time[i1:i2-1], status[i1:i2-1])
+        push!(km, k)
+    end
+
+    return km, unique(group)
+end
+
+# Return a vector of vectors of KaplanMeier values, with the outer
+# index corresponding to strata and the inner index corresponding to
+# groups.  Also returns the unique strata labels, and the unique group
+# labels within each stratum.
+function make_km(time, status, group, strata)
+
+    ii = sortperm(strata)
+    time = time[ii]
+    status = status[ii]
+    group = group[ii]
+
+    strat = sort(unique(strata))
+    groups = []
+    jj = index_splits(strata)
+    km = Vector{Vector{KaplanMeier}}()
+    for j in 1:length(jj)-1
+        i1, i2 = jj[j], jj[j+1]
+        kx, g = make_km(time[i1:i2-1], status[i1:i2-1], group[i1:i2-1])
+        push!(km, kx)
+        push!(groups, g)
+    end
+
+    return km, strat, groups
+end
+
+"""
+    logrank_test(times, status, group) -> NamedTuple
+
+Conduct a hypothesis test for the null hypothesis that n population
+survival functions are equal.  The parameters of the function are
+vectors containing time, status, and group values, with the group
+values defining the distinct populations to be compared.
+"""
+function logrank_test(time, status, group; method=:LogRank, fh=[1., 1.])
+
+    if !(length(time) == length(status) == length(group))
+        @warn("'time', 'status', and 'group' must have equal lengths")
+    end
+
+    psf = if method == :FH
+            fit(KaplanMeier, time, status)
+        else
+            nothing
+        end
+
+    km, _ = make_km(time, status, group)
+
+    return logrank_test(km...; method=method, psf=psf, fh=fh)
+end
+
+# Return a vector containing fitted Kaplan Meier values for the
+# distinct values of strata (sorted).
+function pooled_km(time::AbstractVector, status::AbstractVector, strata::AbstractVector)
+    ii = sortperm(strata)
+    strata = strata[ii]
+    time = time[ii]
+    status = status[ii]
+    jj = index_splits(strata)
+    ps = KaplanMeier[]
+    for j in 1:length(jj)-1
+        j1, j2 = jj[j], jj[j+1]-1
+        k = fit(KaplanMeier, time[j1:j2], status[j1:j2])
+        push!(ps, k)
+    end
+    return ps
+end
+
+"""
+    logrank_test(times, status, group, strata; method, fh) -> NamedTuple
+
+Conduct a hypothesis test for the null hypothesis that n population
+survival functions are equal, using stratified data.  The parameters
+of the function are vectors containing time, status, group, and strata
+values.  The null hypothesis being tested is that the population
+survival functions are identical across groups within each stratum.
+
+The 'method' argument determines the weighting used in the test.
+Options are :LogRank (all weight are 1, the default), :WBG
+(Wilcoxon-Breslow-Gehan, weighting by the number at risk), :TW
+(Tarone-Ware, weighting by the square root of the number at risk), and
+:FH (Fleming-Harrington, weighting by a function of the pooled
+survival function).  If method is :FH, then the 'fh' argument is used
+to specify the exponents in the weight, which is S^fh[1] * (1 -
+S)^fh[2], with S being the estimated survival function at the previous
+time point (pooling over groups but calculated separately by stratum).
+"""
+function logrank_test(time, status, group, strata; method=:LogRank, fh=[1.0, 1.0])
+
+    if !(length(time) == length(status) == length(group) == length(strata))
+        @warn("'times', 'status', 'group', and 'strata' must have equal lengths")
+    end
+
+    km, _, _ = make_km(time, status, group, strata)
+
+    # Get the pooled survival function for each
+    # stratum (pooling over groups within strata).
+    psf = if method == :FH
+            pooled_km(time, status, strata)
+        else
+            fill(nothing, length(km))
+        end
+
+    return logrank_test(km; method=method, psf=psf, fh=fh)
+end

--- a/test/logrank_tests.jl
+++ b/test/logrank_tests.jl
@@ -1,0 +1,90 @@
+@testset "logrank test" begin
+
+    # Simple test with no ties
+    km1 = fit(KaplanMeier, [1, 3, 5], [1, 0, 1])
+    km2 = fit(KaplanMeier, [2, 4, 6], [1, 1, 0])
+    kt1 = logrank_test(km1, km2)
+    kt2 = logrank_test([1, 3, 5, 2, 4, 6], [1, 0, 1, 1, 1, 0], [1, 1, 1, 2, 2, 2])
+    for kt in [kt1, kt2]
+        @test isapprox(kt.stat, 0.073903, atol=1e-5, rtol=1e-5)
+        @test isapprox(kt.dof, 1)
+        @test isapprox(kt.expected, [1.733333, 2.266667], atol=1e-5, rtol=1e-5)
+        @test isapprox(kt.var, [0.9622222 -0.9622222; -0.9622222 0.9622222], atol=1e-5, rtol=1e-5)
+    end
+
+    # Simple test with ties
+    km1 = fit(KaplanMeier, [1, 2, 1], [1, 0, 1])
+    km2 = fit(KaplanMeier, [1, 2, 2], [1, 1, 0])
+    kt = logrank_test(km1, km2)
+    @test isapprox(kt.stat, 0.04132231, atol=1e-5, rtol=1e-5)
+    @test isapprox(kt.dof, 1)
+    @test isapprox(kt.expected, [1.833333, 2.1666667], atol=1e-5, rtol=1e-5)
+    @test isapprox(kt.var, [0.6722222 -0.6722222; -0.6722222 0.6722222], atol=1e-5, rtol=1e-5)
+
+    # Three group test with different sample sizes
+    km1 = fit(KaplanMeier, [1, 2, 1], [1, 0, 1])
+    km2 = fit(KaplanMeier, [1, 2, 2, 3], [1, 1, 0, 1])
+    km3 = fit(KaplanMeier, [1, 2, 2, 4, 5], [1, 1, 0, 0, 1])
+    kt = logrank_test(km1, km2, km3)
+    @test isapprox(kt.stat, 1.507214, atol=1e-5, rtol=1e-5)
+    @test isapprox(kt.dof, 2)
+    @test isapprox(kt.expected, [1.25, 2.41666667, 4.33333], atol=1e-5, rtol=1e-5)
+    @test isapprox(kt.var, [0.7329545 -0.3227814 -0.4101732; 
+                            -0.3227814 1.2704726 -0.9476912;
+                            -0.4101732 -0.9476912 1.3578644], atol=1e-5, rtol=1e-5)
+
+	# Test with stratification.
+	# Column 1 is time, column 2 is status, column 3 is group,
+	# column 4 is strata.
+	da = [1 1 1 1; 3 0 1 1; 5 1 1 1; 2 1 2 1; 4 1 2 1; 6 0 2 1
+		  8 1 1 1; 5 1 1 1; 2 0 1 2; 1 0 2 2; 3 1 2 2; 4 1 2 2]
+	km1 = Vector{Vector{KaplanMeier}}()
+	for j in 1:2 # stratum
+		kx = KaplanMeier[]
+		for i in 1:2 # group
+			ii = (da[:, 3] .== i) .& (da[:, 4] .== j)
+			push!(kx, fit(KaplanMeier, da[ii, 1], da[ii, 2]))
+		end
+		push!(km1, kx)
+	end
+    kt1 = logrank_test(km1)
+	kt2 = logrank_test(da[:,1], da[:,2], da[:,3], da[:,4])
+	for kt in [kt1, kt2]
+		@test isapprox(kt.stat, 0.09065547, atol=1e-5, rtol=1e-5)
+		@test isapprox(kt.dof, 1)
+		@test isapprox(kt.expected, [4.3, 3.7], atol=0.1, rtol=0.1)
+	end
+
+	# Test with Wilcoxon weights
+	# Stata seems to report the unweighted expected values
+	# whereas we are reporing the weighted expected values,
+	# so the expected values are not tested here.
+	kt = logrank_test(da[:,1], da[:,2], da[:,3]; method=:WBG)
+	@test isapprox(kt.stat, 0.51362, atol=1e-5, rtol=1e-5)
+	@test isapprox(kt.dof, 1)
+
+	# Test with Wilcoxon weights and strata
+	kt = logrank_test(da[:,1], da[:,2], da[:,3], da[:,4]; method=:WBG)
+	@test isapprox(kt.stat, 0.10810811, atol=1e-5, rtol=1e-5)
+	@test isapprox(kt.dof, 1)
+
+	# Test with Tarone-Ware weights and strata
+	kt = logrank_test(da[:,1], da[:,2], da[:,3], da[:,4]; method=:TW)
+	@test isapprox(kt.stat, 0.10857866, atol=1e-5, rtol=1e-5)
+	@test isapprox(kt.dof, 1)
+
+	# Test with Fleming-Harrington weights
+	kt = logrank_test(da[:,1], da[:,2], da[:,3]; method=:FH)
+	@test isapprox(kt.stat, 0.9047277, atol=1e-5, rtol=1e-5)
+	@test isapprox(kt.dof, 1)
+
+	# Test with Fleming-Harrington weights and strata
+	kt = logrank_test(da[:,1], da[:,2], da[:,3], da[:,4]; method=:FH)
+	@test isapprox(kt.stat, 0.11739737, atol=1e-5, rtol=1e-5)
+	@test isapprox(kt.dof, 1)
+
+	# Another test with Fleming-Harrington weights and strata
+	kt = logrank_test(da[:,1], da[:,2], da[:,3], da[:,4]; method=:FH, fh=[0.6, 0.2])
+	@test isapprox(kt.stat, 0.63748839, atol=1e-5, rtol=1e-5)
+	@test isapprox(kt.dof, 1)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -256,3 +256,5 @@ x7   0.0914971  0.0286485   3.19378     0.0014
     @test coeftable(outcome_fincatracecat).rownms == ["fin: 1", "race: 1","fin: 1 & race: 1"]
     @test coef(outcome_fincatracecat) ≈ coef(outcome_finrace) atol=1e-8
 end
+
+include("logrank_tests.jl")


### PR DESCRIPTION
This PR adds log rank testing for comparing two or more fitted survival functions (fit with the Kaplan Meier estimator).

The unit tests are based on results from R and Stata.
