### PR TITLE
Simplifications and performance improvements for estimators

### DIFF
--- a/src/estimator.jl
+++ b/src/estimator.jl
@@ -2,26 +2,45 @@
 #  * The input is nonempty
 #  * Time 0 is not included
 
-function _estimator(::Type{S}, tte::AbstractVector{T}, status::BitVector) where {S, T}
-    nobs = length(tte)
+function _n_unique_times(ets)
+    # We know that `ets` is nonempty and sorted ascending by the `time` fields of the
+    # elements, so we can count the unique values in `O(length(ets))` time with no
+    # allocations by only comparing to the last observed unique time
+    t_prev = first(ets).time
+    n = 1
+    for et in Iterators.drop(ets, 1)
+        t = et.time
+        if t != t_prev
+            n += 1
+            t_prev = t
+        end
+    end
+    return n
+end
+
+function _estimator(::Type{S}, ets::AbstractVector{EventTime{T}}) where {S,T}
+    outlen = _n_unique_times(ets)
+
+    nobs = length(ets)
     dᵢ = 0                   # Number of observed events at time t
     cᵢ = 0                   # Number of censored events at time t
     nᵢ = nobs                # Number remaining at risk at time t
     es = estimator_start(S)  # Estimator starting point
     gw = stderr_start(S)     # Standard Error starting point
 
-    times = T[]              # The set of unique event times
-    nevents = Int[]          # Total observed events at each time
-    ncensor = Int[]          # Total censored events at each time
-    natrisk = Int[]          # Number at risk at each time
-    estimator = Float64[]    # Estimates
-    stderr = Float64[]       # Pointwise standard errors
+    times = Vector{T}(undef, outlen)            # The set of unique event times
+    nevents = Vector{Int}(undef, outlen)        # Total observed events at each time
+    ncensor = Vector{Int}(undef, outlen)        # Total censored events at each time
+    natrisk = Vector{Int}(undef, outlen)        # Number at risk at each time
+    estimator = Vector{Float64}(undef, outlen)  # Estimates
+    stderr = Vector{Float64}(undef, outlen)     # Pointwise standard errors
 
     t_prev = zero(T)
+    outind = 1
 
-    @inbounds for i = 1:nobs
-        t = tte[i]
-        s = status[i]
+    @inbounds for obsind in eachindex(ets)
+        t = ets[obsind].time
+        s = ets[obsind].status
         # Aggregate over tied times
         if t == t_prev
             dᵢ += s
@@ -30,12 +49,13 @@ function _estimator(::Type{S}, tte::AbstractVector{T}, status::BitVector) where 
         elseif !iszero(t_prev)
             es = estimator_update(S, es, dᵢ, nᵢ)
             gw = stderr_update(S, gw, dᵢ, nᵢ)
-            push!(times, t_prev)
-            push!(nevents, dᵢ)
-            push!(ncensor, cᵢ)
-            push!(natrisk, nᵢ)
-            push!(estimator, es)
-            push!(stderr, sqrt(gw))
+            times[outind] = t_prev
+            nevents[outind] = dᵢ
+            ncensor[outind] = cᵢ
+            natrisk[outind] = nᵢ
+            estimator[outind] = es
+            stderr[outind] = sqrt(gw)
+            outind += 1
         end
         nᵢ -= dᵢ + cᵢ
         dᵢ = s
@@ -45,12 +65,12 @@ function _estimator(::Type{S}, tte::AbstractVector{T}, status::BitVector) where 
 
     # We need to do this one more time to capture the last time
     # since everything in the loop is lagged
-    push!(times, t_prev)
-    push!(nevents, dᵢ)
-    push!(ncensor, cᵢ)
-    push!(natrisk, nᵢ)
-    push!(estimator, es)
-    push!(stderr, sqrt(gw))
+    times[outind] = t_prev
+    nevents[outind] = dᵢ
+    ncensor[outind] = cᵢ
+    natrisk[outind] = nᵢ
+    estimator[outind] = es
+    stderr[outind] = sqrt(gw)
 
     return S{T}(times, nevents, ncensor, natrisk, estimator, stderr)
 end
@@ -58,26 +78,16 @@ end
 function StatsBase.fit(::Type{S},
                        times::AbstractVector{T},
                        status::AbstractVector{<:Integer}) where {S<:NonparametricEstimator,T}
-    nobs = length(times)
-    if length(status) != nobs
-        throw(DimensionMismatch("there must be as many event statuses as times"))
+    ntimes = length(times)
+    nstatus = length(status)
+    if ntimes != nstatus
+        throw(DimensionMismatch("number of event statuses does not match number of " *
+                                "event times; got $nstatus and $ntimes, respectively"))
     end
-    if nobs == 0
-        throw(ArgumentError("the sample must be nonempty"))
-    end
-    p = sortperm(times)
-    t = times[p]
-    s = BitVector(status[p])
-    return _estimator(S, t, s)
+    return fit(S, map(EventTime{T}, times, status))
 end
 
 function StatsBase.fit(::Type{S}, ets::AbstractVector{<:EventTime}) where S<:NonparametricEstimator
-    length(ets) > 0 || throw(ArgumentError("the sample must be nonempty"))
-    x = sort(ets)
-    # TODO: Refactor, since iterating over the EventTime objects directly in
-    # the _km loop may actually be easier/more efficient than working with
-    # the times and statuses as separate vectors. Plus it might be nice to
-    # make this method the One True Method™ so that folks are encouraged to
-    # use EventTimes instead of raw values.
-    return fit(S, map(t->t.time, x), BitVector(map(t->t.status, x)))
+    isempty(ets) && throw(ArgumentError("can't compute $(nameof(S)) from 0 observations"))
+    return _estimator(S, issorted(ets) ? ets : sort(ets))
 end

--- a/src/kaplanmeier.jl
+++ b/src/kaplanmeier.jl
@@ -49,7 +49,15 @@ end
     fit(KaplanMeier, times, status) -> KaplanMeier
 
 Given a vector of times to events and a corresponding vector of indicators that
-dictate whether each time is an observed event or is right censored, compute the
+denote whether each time is an observed event or is right censored, compute the
 Kaplan-Meier estimate of the survivor function.
 """
 StatsBase.fit(::Type{KaplanMeier}, times, status)
+
+"""
+    fit(KaplanMeier, ets) -> KaplanMeier
+
+Compute the Kaplan-Meier estimate of the survivor function from a vector of
+[`EventTime`](@ref) values.
+"""
+StatsBase.fit(::Type{KaplanMeier}, ets)

--- a/src/nelsonaalen.jl
+++ b/src/nelsonaalen.jl
@@ -46,7 +46,15 @@ end
     fit(NelsonAalen, times, status) -> NelsonAalen
 
 Given a vector of times to events and a corresponding vector of indicators that
-dictate whether each time is an observed event or is right censored, compute the
+denote whether each time is an observed event or is right censored, compute the
 Nelson-Aalen estimate of the cumulative hazard rate function.
 """
 StatsBase.fit(::Type{NelsonAalen}, times, status)
+
+"""
+    fit(NelsonAalen, ets) -> NelsonAalen
+
+Compute the Nelson-Aalen estimate of the cumulative hazard rate function from a
+vector of [`EventTime`](@ref) values.
+"""
+StatsBase.fit(::Type{NelsonAalen}, ets)


### PR DESCRIPTION
We can very cheaply determine ahead of time the correct length for the output arrays stored by the estimator types, which allows us to set indices directly rather than repeatedly growing the arrays. This provides a decent improvement in performance and memory use.

Current master:
```julia
julia> @benchmark fit(KaplanMeier, $t, $s)
BenchmarkTools.Trial: 10000 samples with 4 evaluations.
 Range (min … max):  7.563 μs … 242.163 μs  ┊ GC (min … max): 0.00% … 93.11%
 Time  (median):     8.176 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   8.810 μs ±   7.397 μs  ┊ GC (mean ± σ):  2.74% ±  3.20%

  ▃▃▅▆█▅▂▁        ▁    ▁▁                                     ▁
  ████████████▇▇█▇██▇█▇██▇▅▅▅▅▄▄▄▅▅▄▅▄▄▃▄▅▃▄▄▄▅▄▆▅▅▆▅▅▅▄▅▅▅▇█ █
  7.56 μs      Histogram: log(frequency) by time      15.8 μs <

 Memory estimate: 14.05 KiB, allocs estimate: 30.
```
This PR:
```julia
julia> @benchmark fit(KaplanMeier, $t, $s)
BenchmarkTools.Trial: 10000 samples with 8 evaluations.
 Range (min … max):  2.875 μs … 66.797 μs  ┊ GC (min … max): 0.00% … 86.05%
 Time  (median):     3.074 μs              ┊ GC (median):    0.00%
 Time  (mean ± σ):   3.267 μs ±  2.090 μs  ┊ GC (mean ± σ):  2.19% ±  3.32%

    ▃▆███▇▅▄▃▂▂▂▁                         ▁▁▂▂▂▁             ▂
  ▅▆██████████████▇▇▆▆▅▅▃▅▅▅▄▄▃▅▁▃▆▇█████████████▇▆▅▁▃▃▅▆▆▆▆ █
  2.87 μs      Histogram: log(frequency) by time     4.79 μs <

 Memory estimate: 8.75 KiB, allocs estimate: 10.
```
Here, `t` and `s` are defined as in the tests for `KaplanMeier`.

I've also taken care of a 5-year-old to-do item and unified the `fit` methods to favor using `EventTime`s rather than separate arrays. This simplifies things a bit.

Lastly, I fixed similarly long-standing docstring typos (I meant "denote," not "dictate") for the `fit` methods and added docstrings for the methods that take a single vector of `EventTime`s.