### PR TITLE
Remove `<:Real` restrictions on type parameters and allow non-`Float64` results

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -28,7 +28,8 @@ julia = "1.6"
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
 CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
+Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["CategoricalArrays", "CSV", "DataFrames", "Test"]
+test = ["CategoricalArrays", "CSV", "DataFrames", "Dates", "Test"]

--- a/src/eventtimes.jl
+++ b/src/eventtimes.jl
@@ -1,4 +1,6 @@
-#-- EventTime ---------------
+#####
+##### `EventTime`
+#####
 
 ## Type constructors
 
@@ -8,7 +10,7 @@
 Immutable object containing the real-valued time to an event as well as an indicator of
 whether the time corresponds to an observed event (`true`) or right censoring (`false`).
 """
-struct EventTime{T<:Real}
+struct EventTime{T}
     time::T
     status::Bool
 end
@@ -18,7 +20,12 @@ EventTime(time, status=true) = EventTime{typeof(time)}(time, Bool(status))
 ## Overloaded Base functions
 
 Base.eltype(::Type{EventTime{T}}) where {T} = T
-Base.show(io::IO, ev::EventTime) = print(io, ev.time, ifelse(ev.status, "", "+"))
+
+function Base.show(io::IO, ev::EventTime)
+    show(io, ev.time)
+    iscensored(ev) && print(io, '+')
+    return nothing
+end
 
 Base.convert(T::Type{<:Real}, ev::EventTime) = convert(T, ev.time)
 Base.convert(T::Type{EventTime}, x::Real) = EventTime(x)

--- a/src/kaplanmeier.jl
+++ b/src/kaplanmeier.jl
@@ -13,7 +13,7 @@ The type has the following fields:
 Use `fit(KaplanMeier, ...)` to compute the estimates and construct
 this type.
 """
-struct KaplanMeier{T<:Real} <: NonparametricEstimator
+struct KaplanMeier{T} <: NonparametricEstimator
     events::EventTable{T}
     survival::Vector{Float64}
     stderr::Vector{Float64}

--- a/src/kaplanmeier.jl
+++ b/src/kaplanmeier.jl
@@ -1,29 +1,36 @@
 """
-    KaplanMeier
+    KaplanMeier{S,T}
 
 An immutable type containing survivor function estimates computed
 using the Kaplan-Meier method.
 The type has the following fields:
 
 * `events`: An [`EventTable`](@ref) summarizing the times and events
-  used to comute the estimates
-* `survival`: Estimate of the survival probability at each time
-* `stderr`: Standard error of the log survivor function at each time
+  used to compute the estimates. The time values are of type `T`.
+* `survival`: Estimate of the survival probability at each time. Values
+  are of type `S`.
+* `stderr`: Standard error of the log survivor function at each time.
+  Values are of type `S`.
 
-Use `fit(KaplanMeier, ...)` to compute the estimates and construct
-this type.
+Use `fit(KaplanMeier, ...)` to compute the estimates as `Float64`
+values and construct this type.
+Alternatively, `fit(KaplanMeier{S}, ...)` may be used to request a
+particular value type `S` for the estimates.
 """
-struct KaplanMeier{T} <: NonparametricEstimator
+struct KaplanMeier{S,T} <: NonparametricEstimator
     events::EventTable{T}
-    survival::Vector{Float64}
-    stderr::Vector{Float64}
+    survival::Vector{S}
+    stderr::Vector{S}
 end
 
-estimator_start(::Type{KaplanMeier}) = 1.0  # Estimator starting point
-stderr_start(::Type{KaplanMeier}) = 0.0 # StdErr starting point
+estimator_eltype(::Type{<:KaplanMeier{S}}) where {S} = S
+estimator_eltype(::Type{KaplanMeier}) = Float64
 
-estimator_update(::Type{KaplanMeier}, es, dᵢ, nᵢ) = es * (1 - dᵢ / nᵢ) # Estimator update rule
-stderr_update(::Type{KaplanMeier}, gw, dᵢ, nᵢ) = gw + dᵢ / (nᵢ * (nᵢ - dᵢ)) # StdErr update rule
+estimator_start(T::Type{<:KaplanMeier}) = oneunit(estimator_eltype(T))
+stderr_start(T::Type{<:KaplanMeier}) = zero(estimator_eltype(T))
+
+estimator_update(::Type{<:KaplanMeier}, es, dᵢ, nᵢ) = es * (1 - dᵢ // nᵢ)
+stderr_update(::Type{<:KaplanMeier}, gw, dᵢ, nᵢ) = gw + dᵢ // (nᵢ * (nᵢ - dᵢ))
 
 """
     confint(km::KaplanMeier; level=0.05)

--- a/src/nelsonaalen.jl
+++ b/src/nelsonaalen.jl
@@ -12,7 +12,7 @@ The type has the following fields:
 Use `fit(NelsonAalen, ...)` to compute the estimates and construct
 this type.
 """
-struct NelsonAalen{T<:Real} <: NonparametricEstimator
+struct NelsonAalen{T} <: NonparametricEstimator
     events::EventTable{T}
     chaz::Vector{Float64}
     stderr::Vector{Float64}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -153,6 +153,13 @@ end
     @test km.survival ≈ km_et.survival
     @test km.stderr ≈ km_et.stderr
 
+    km_f32 = fit(KaplanMeier{Float32}, t, s)
+    @test km.events == km_f32.events
+    @test eltype(km_f32.survival) === Float32
+    @test eltype(km_f32.stderr) === Float32
+    @test km.survival ≈ km_f32.survival
+    @test km.stderr ≈ km_f32.stderr
+
     @test_throws ArgumentError fit(KaplanMeier, EventTime{Int}[])
 
     @test_deprecated confint(km, 0.05)
@@ -188,6 +195,13 @@ end
     na_lower, na_upper = getindex.(na_conf, 1), getindex.(na_conf, 2)
     @test cdf.(Normal.(na.chaz, na.stderr), na_lower) ≈ fill(0.005, length(na.chaz)) rtol=1e-8
     @test cdf.(Normal.(na.chaz, na.stderr), na_upper) ≈ fill(0.995, length(na.chaz)) rtol=1e-8
+
+    na_f32 = fit(NelsonAalen{Float32}, t, s)
+    @test na.events == na_f32.events
+    @test eltype(na_f32.chaz) === Float32
+    @test eltype(na_f32.stderr) === Float32
+    @test na.chaz ≈ na_f32.chaz
+    @test na.stderr ≈ na_f32.stderr
 
     @test_deprecated confint(na, 0.05)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ using Survival
 using Test
 using CSV
 using DataFrames
+using Dates
 using CategoricalArrays
 using Distributions
 using LinearAlgebra
@@ -33,6 +34,8 @@ using Tables
     let x = [EventTime(2, false), EventTime(1), EventTime(2)]
         @test sort(x) == [EventTime(1), EventTime(2), EventTime(2, false)]
     end
+
+    @test isevent(EventTime(Day(420)))
 end
 
 @testset "Kaplan-Meier" begin
@@ -306,4 +309,7 @@ end
     @test EventTable(Float32[], Int[]) == EventTable{Float32}(Float32[], Int[], Int[], Int[])
     witht0 = vcat(EventTime(0), map(EventTime, t, s))
     @test !any(iszero, EventTable(witht0).time)
+    dates = EventTable(Year.(t), s)
+    @test all(x -> getfield(et, x) == getfield(dates, x), (:nevents, :ncensored, :natrisk))
+    @test et.time == Dates.value.(dates.time)
 end


### PR DESCRIPTION
I've separated the changes into two commits. See commit messages for details.