### PR TITLE
Fix typo in docs: delete an extra parenthesis in a code chunk

### DIFF
--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -22,7 +22,7 @@ and [DataFrames](https://github.com/JuliaData/DataFrames.jl) packages.
 ```julia-repl
 julia> using Survival, StatsModels, CSV, DataFrames
 
-julia> rossi = CSV.read(joinpath(pkgdir(Survival), "test", "data", "rossi.csv")), DataFrame);
+julia> rossi = CSV.read(joinpath(pkgdir(Survival), "test", "data", "rossi.csv"), DataFrame);
 ```
 
 ### Fitting the model


### PR DESCRIPTION
Thanks for a great package.

I noticed a typo in the Getting Started guide.