### PR TITLE
Rely on the registry on the package server

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -25,8 +25,6 @@ jobs:
           using Pkg
           Pkg.Registry.add("General")
         shell: julia --color=yes {0}
-        env:
-          JULIA_PKG_SERVER: ""
       - name: "Install CompatHelper"
         run: |
           using Pkg, UUIDs


### PR DESCRIPTION
To avoid excessive download. I don't think the small delays matter for the CompatHelper runs and using the registry on the package server requires a much smaller download.