### PR TITLE
Fix level argument in confint for KaplanMeier and NelsonAalen

### DIFF
--- a/src/kaplanmeier.jl
+++ b/src/kaplanmeier.jl
@@ -38,8 +38,8 @@ stderr_update(::Type{<:KaplanMeier}, gw, dᵢ, nᵢ) = gw + dᵢ // (nᵢ * (n�
 Compute the pointwise log-log transformed confidence intervals for the survivor
 function as a vector of tuples.
 """
-function StatsAPI.confint(km::KaplanMeier; level::Real=0.05)
-    q = quantile(Normal(), 1 - level/2)
+function StatsAPI.confint(km::KaplanMeier; level::Real=0.95)
+    q = quantile(Normal(), (1 + level)/2)
     return map(km.survival, km.stderr) do srv, se
         l = log(-log(srv))
         a = q * se / log(srv)

--- a/src/kaplanmeier.jl
+++ b/src/kaplanmeier.jl
@@ -33,7 +33,7 @@ estimator_update(::Type{<:KaplanMeier}, es, dᵢ, nᵢ) = es * (1 - dᵢ // nᵢ
 stderr_update(::Type{<:KaplanMeier}, gw, dᵢ, nᵢ) = gw + dᵢ // (nᵢ * (nᵢ - dᵢ))
 
 """
-    confint(km::KaplanMeier; level=0.05)
+    confint(km::KaplanMeier; level=0.95)
 
 Compute the pointwise log-log transformed confidence intervals for the survivor
 function as a vector of tuples.

--- a/src/nelsonaalen.jl
+++ b/src/nelsonaalen.jl
@@ -33,7 +33,7 @@ estimator_update(::Type{<:NelsonAalen}, es, dᵢ, nᵢ) = es + dᵢ // nᵢ
 stderr_update(::Type{<:NelsonAalen}, gw, dᵢ, nᵢ) = gw + dᵢ * (nᵢ - dᵢ) // (nᵢ^3)
 
 """
-    confint(na::NelsonAalen; level=0.05)
+    confint(na::NelsonAalen; level=0.95)
 
 Compute the pointwise confidence intervals for the cumulative hazard
 function as a vector of tuples.

--- a/src/nelsonaalen.jl
+++ b/src/nelsonaalen.jl
@@ -38,8 +38,8 @@ stderr_update(::Type{<:NelsonAalen}, gw, dᵢ, nᵢ) = gw + dᵢ * (nᵢ - dᵢ)
 Compute the pointwise confidence intervals for the cumulative hazard
 function as a vector of tuples.
 """
-function StatsAPI.confint(na::NelsonAalen; level::Real=0.05)
-    q = quantile(Normal(), 1 - level/2)
+function StatsAPI.confint(na::NelsonAalen; level::Real=0.95)
+    q = quantile(Normal(), (1 + level)/2)
     return map(na.chaz, na.stderr) do srv, se
         srv - q * se, srv + q * se
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -200,8 +200,8 @@ end
     @test cdf.(Normal.(na.chaz, na.stderr), na_lower) ≈ fill(0.005, length(na.chaz)) rtol=1e-8
     @test cdf.(Normal.(na.chaz, na.stderr), na_upper) ≈ fill(0.995, length(na.chaz)) rtol=1e-8
     na_conf_95 = confint(na; level=0.95)
-    @test all(getindex.(na_conf, 1) .<= getindex.(na_conf_95, 1))
-    @test all(getindex.(na_conf, 2) .>= getindex.(na_conf_95, 2))
+    @test all(first.(na_conf) .<= first.(na_conf_95))
+    @test all(last.(na_conf) .>= last.(na_conf_95))
 
     na_f32 = fit(NelsonAalen{Float32}, t, s)
     @test na.events == na_f32.events

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -146,8 +146,8 @@ end
     @test jl_upper ≈ r_upper atol=1e-6
 
     conf_99 = confint(km; level=0.99)
-    @test all(getindex.(conf_99, 1) .<= getindex.(conf, 1))
-    @test all(getindex.(conf_99, 2) .>= getindex.(conf, 2))
+    @test all(first.(conf_99) .<= first.(conf))
+    @test all(last.(conf_99) .>= last.(conf))
 
     @test_throws DimensionMismatch fit(KaplanMeier, [1, 2], [true])
     @test_throws ArgumentError fit(KaplanMeier, Float64[], Bool[])

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -145,6 +145,10 @@ end
     @test jl_lower ≈ r_lower atol=1e-6
     @test jl_upper ≈ r_upper atol=1e-6
 
+    conf_99 = confint(km; level=0.99)
+    @test all(getindex.(conf_99, 1) .<= getindex.(conf, 1))
+    @test all(getindex.(conf_99, 2) .>= getindex.(conf, 2))
+
     @test_throws DimensionMismatch fit(KaplanMeier, [1, 2], [true])
     @test_throws ArgumentError fit(KaplanMeier, Float64[], Bool[])
 
@@ -191,10 +195,13 @@ end
     na_lower, na_upper = getindex.(na_conf, 1), getindex.(na_conf, 2)
     @test cdf.(Normal.(na.chaz, na.stderr), na_lower) ≈ fill(0.025, length(na.chaz)) rtol=1e-8
     @test cdf.(Normal.(na.chaz, na.stderr), na_upper) ≈ fill(0.975, length(na.chaz)) rtol=1e-8
-    na_conf = confint(na; level=0.01)
+    na_conf = confint(na; level=0.99)
     na_lower, na_upper = getindex.(na_conf, 1), getindex.(na_conf, 2)
     @test cdf.(Normal.(na.chaz, na.stderr), na_lower) ≈ fill(0.005, length(na.chaz)) rtol=1e-8
     @test cdf.(Normal.(na.chaz, na.stderr), na_upper) ≈ fill(0.995, length(na.chaz)) rtol=1e-8
+    na_conf_95 = confint(na; level=0.95)
+    @test all(getindex.(na_conf, 1) .<= getindex.(na_conf_95, 1))
+    @test all(getindex.(na_conf, 2) .>= getindex.(na_conf_95, 2))
 
     na_f32 = fit(NelsonAalen{Float32}, t, s)
     @test na.events == na_f32.events


### PR DESCRIPTION
The argument used to be alpha when it was positional. When it became a keyword argument, it was changed to level, but the update here kept using it as alpha instead level.