### PR TITLE
Add AlgebraOfGraphics extension for Kaplan-Meier plots

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -38,7 +38,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: julia-actions/julia-docdeploy@latest
+      - uses: julia-actions/setup-julia@v2
+        with:
+          version: '1'
+      - uses: julia-actions/cache@v3
+      - name: Build docs with coverage
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
+        run: julia --project=docs --code-coverage=user -e '
+          using Pkg;
+          Pkg.develop(PackageSpec(path=pwd()));
+          Pkg.instantiate();
+          include("docs/make.jl")'
+      - uses: julia-actions/julia-processcoverage@v1
+      - uses: codecov/codecov-action@v5
+        with:
+          files: lcov.info
+          flags: docs
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,14 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 StatsModels = "3eaba693-59b7-5ba5-a881-562e759f1c8d"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
+[weakdeps]
+AlgebraOfGraphics = "cbdf2221-f076-402e-a563-3d30da359d67"
+
+[extensions]
+SurvivalAlgebraOfGraphicsExt = "AlgebraOfGraphics"
+
 [compat]
+AlgebraOfGraphics = "0.12"
 CategoricalArrays = "0.9, 0.10, 1"
 Compat = "3.43, 4"
 DataFrames = "1"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,11 +1,14 @@
 [deps]
+AlgebraOfGraphics = "cbdf2221-f076-402e-a563-3d30da359d67"
+CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+RDatasets = "ce6b1742-4840-55fa-b093-852dadbb1d8b"
 StatsAPI = "82ae8749-77ed-4fe6-ae5f-f523153014b0"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 Survival = "8a913413-2070-5976-9d4c-2b364fdc2f7f"
 
-[compat]
-Documenter = "~0.27"
-
 [sources]
-Survival = { path = ".." }
+Survival = {path = "/Users/andreasnoack/.julia/dev/Survival"}
+
+[compat]
+Documenter = "1"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -8,7 +8,7 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 Survival = "8a913413-2070-5976-9d4c-2b364fdc2f7f"
 
 [sources]
-Survival = {path = "/Users/andreasnoack/.julia/dev/Survival"}
+Survival = {path = ".."}
 
 [compat]
 Documenter = "1"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -17,4 +17,5 @@ makedocs(
 deploydocs(
     repo = "github.com/JuliaStats/Survival.jl.git",
     target = "build",
+    push_preview = true,
 )

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,7 +1,7 @@
-using Survival, Documenter, StatsBase, StatsAPI
+using Survival, Documenter, StatsBase, StatsAPI, AlgebraOfGraphics, CairoMakie, RDatasets
 
 makedocs(
-    modules = [Survival],
+    modules = [Survival, Base.get_extension(Survival, :SurvivalAlgebraOfGraphicsExt)::Module],
     sitename = "Survival.jl",
     authors = "Alex Arslan",
     pages = [

--- a/docs/src/km.md
+++ b/docs/src/km.md
@@ -110,7 +110,6 @@ StatsAPI.fit(::Type{KaplanMeier}, ::Any)
 StatsAPI.confint(::KaplanMeier)
 Survival.kaplanmeier
 Survival.censorticks
-Survival.risktable_at
 Survival.add_risktable!
 ```
 

--- a/docs/src/km.md
+++ b/docs/src/km.md
@@ -20,12 +20,89 @@ using Greenwood's formula:
 \text{SE}(\log \hat{S}(t)) = \sqrt{\sum_{i: t_i < t} \frac{d_i}{n_i (n_i - d_i)}}
 ```
 
+## Plotting
+
+Survival.jl provides an [AlgebraOfGraphics.jl](https://github.com/MakieOrg/AlgebraOfGraphics.jl)
+extension for creating Kaplan-Meier plots. The extension is loaded automatically when both
+Survival and AlgebraOfGraphics are available.
+
+```@example km
+using Survival, AlgebraOfGraphics, CairoMakie, RDatasets
+
+lung = dataset("survival", "lung")
+lung.Event = lung.Status .== 2
+lung.SexLabel = replace.(string.(lung.Sex), "1" => "Male", "2" => "Female")
+first(lung, 5)
+```
+
+### Basic Kaplan-Meier Plot
+
+Map time and event indicator columns to the first two positional arguments of
+`kaplanmeier()`:
+
+```@example km
+plt = data(lung) * mapping("Time", "Event") * (kaplanmeier() + censorticks())
+draw(plt)
+```
+
+### Grouped Kaplan-Meier Plot
+
+Use the `color` mapping to stratify by a grouping variable.
+The `marker` mapping is applied only to `censorticks()` so that the censor
+marks get group-specific marker shapes:
+
+```@example km
+plt = data(lung) * mapping("Time", "Event", color="SexLabel") *
+    (kaplanmeier() + mapping(marker="SexLabel") * censorticks())
+draw(plt)
+```
+
+### Adding a Risk Table
+
+Call `add_risktable!` on the result of `draw()` to add a number-at-risk table
+below the plot:
+
+```@example km
+plt = data(lung) * mapping("Time", "Event", color="SexLabel") *
+    (kaplanmeier() + mapping(marker="SexLabel") * censorticks())
+fg = draw(plt)
+add_risktable!(fg)
+fg
+```
+
+### Faceted by Column
+
+Use the `col` mapping to display groups in separate panels.
+`add_risktable!` works with faceted layouts as well:
+
+```@example km
+plt = data(lung) * mapping("Time", "Event", col="SexLabel") *
+    (kaplanmeier() + censorticks())
+fg = draw(plt)
+add_risktable!(fg)
+fg
+```
+
+### Without Confidence Interval
+
+Pass `interval=nothing` to show only the survival curve:
+
+```@example km
+plt = data(lung) * mapping("Time", "Event") * kaplanmeier(interval=nothing)
+draw(plt)
+```
+
 ## API
 
 ```@docs
 Survival.KaplanMeier
 StatsAPI.fit(::Type{KaplanMeier}, ::Any, ::Any)
+StatsAPI.fit(::Type{KaplanMeier}, ::Any)
 StatsAPI.confint(::KaplanMeier)
+Survival.kaplanmeier
+Survival.censorticks
+Survival.risktable_at
+Survival.add_risktable!
 ```
 
 ## References

--- a/docs/src/km.md
+++ b/docs/src/km.md
@@ -83,6 +83,15 @@ add_risktable!(fg)
 fg
 ```
 
+### Custom Confidence Level
+
+Use the `level` keyword to change the confidence level (default 0.95):
+
+```@example km
+plt = data(lung) * mapping("Time", "Event") * (kaplanmeier(level=0.9) + censorticks())
+draw(plt)
+```
+
 ### Without Confidence Interval
 
 Pass `interval=nothing` to show only the survival curve:

--- a/docs/src/na.md
+++ b/docs/src/na.md
@@ -25,6 +25,7 @@ from ``n_i`` samples:
 ```@docs
 Survival.NelsonAalen
 StatsAPI.fit(::Type{NelsonAalen}, ::Any, ::Any)
+StatsAPI.fit(::Type{NelsonAalen}, ::Any)
 StatsAPI.confint(::NelsonAalen)
 ```
 

--- a/ext/SurvivalAlgebraOfGraphicsExt.jl
+++ b/ext/SurvivalAlgebraOfGraphicsExt.jl
@@ -6,7 +6,7 @@ using AlgebraOfGraphics
 using AlgebraOfGraphics: transformation, ProcessedLayer, ProcessedLayers, dictionary, verbatim
 using AlgebraOfGraphics.Makie: Makie, Stairs, Band, Scatter, Axis, to_value, text!, hidexdecorations!, linkxaxes!, ylims!
 
-import Survival: kaplanmeier, censorticks, risktable_at, add_risktable!
+import Survival: kaplanmeier, censorticks, add_risktable!
 
 # ── Helper: stepped band coordinates ────────────────────────────────────────
 
@@ -27,11 +27,7 @@ end
 
 # ── risktable_at ────────────────────────────────────────────────────────────
 
-"""
-    risktable_at(km::KaplanMeier, timepoints)
-
-Compute at-risk counts at specified time points from a KaplanMeier fit.
-"""
+# Compute at-risk counts at specified time points from a KaplanMeier fit.
 function risktable_at(km::KaplanMeier, timepoints)
     map(timepoints) do t
         idx = searchsortedfirst(km.events.time, t)

--- a/ext/SurvivalAlgebraOfGraphicsExt.jl
+++ b/ext/SurvivalAlgebraOfGraphicsExt.jl
@@ -43,6 +43,7 @@ end
 
 Base.@kwdef struct KaplanMeierAnalysis
     interval::Union{Symbol,Nothing} = :confidence
+    level::Float64 = 0.95
 end
 
 function (a::KaplanMeierAnalysis)(input::ProcessedLayer)
@@ -53,7 +54,7 @@ function (a::KaplanMeierAnalysis)(input::ProcessedLayer)
     output = AlgebraOfGraphics.map(input) do p, n
         time, event = p
         km = fit(KaplanMeier, time, BitVector(event))
-        ci = confint(km)
+        ci = confint(km; level=a.level)
 
         t = [0.0; km.events.time]
         s = [1.0; km.survival]
@@ -118,7 +119,7 @@ function (a::KaplanMeierAnalysis)(input::ProcessedLayer)
 end
 
 """
-    kaplanmeier(; interval=:confidence)
+    kaplanmeier(; interval=:confidence, level=0.95)
 
 Compute a Kaplan-Meier survival estimate as an AlgebraOfGraphics transformation.
 
@@ -126,7 +127,8 @@ The first positional mapping should be time, the second the event indicator
 (0/1 or Bool).
 
 Use `interval=:confidence` (default) for confidence bands, or
-`interval=nothing` for just the survival curve.
+`interval=nothing` for just the survival curve. The `level` keyword
+controls the confidence level (default 0.95).
 
 Grouping (e.g. `color=:treatment`) is handled automatically by AlgebraOfGraphics.
 """

--- a/ext/SurvivalAlgebraOfGraphicsExt.jl
+++ b/ext/SurvivalAlgebraOfGraphicsExt.jl
@@ -1,0 +1,276 @@
+module SurvivalAlgebraOfGraphicsExt
+
+using Survival
+using Survival: KaplanMeier, EventTable, fit, confint
+using AlgebraOfGraphics
+using AlgebraOfGraphics: transformation, ProcessedLayer, ProcessedLayers, dictionary, verbatim
+using AlgebraOfGraphics.Makie: Makie, Stairs, Band, Scatter, Axis, to_value, text!, hidexdecorations!, linkxaxes!, ylims!
+
+import Survival: kaplanmeier, censorticks, risktable_at, add_risktable!
+
+# ── Helper: stepped band coordinates ────────────────────────────────────────
+
+# Duplicate points to create stepped band coordinates for use with `Band`,
+# which otherwise linearly interpolates between points.
+function step_band_coords(t, lo, hi)
+    n = length(t)
+    st  = Vector{Float64}(undef, 2n - 1)
+    slo = Vector{Float64}(undef, 2n - 1)
+    shi = Vector{Float64}(undef, 2n - 1)
+    for i in 1:n-1
+        st[2i-1]  = t[i];   slo[2i-1] = lo[i]; shi[2i-1] = hi[i]
+        st[2i]    = t[i+1]; slo[2i]   = lo[i]; shi[2i]   = hi[i]
+    end
+    st[2n-1] = t[n]; slo[2n-1] = lo[n]; shi[2n-1] = hi[n]
+    st, slo, shi
+end
+
+# ── risktable_at ────────────────────────────────────────────────────────────
+
+"""
+    risktable_at(km::KaplanMeier, timepoints)
+
+Compute at-risk counts at specified time points from a KaplanMeier fit.
+"""
+function risktable_at(km::KaplanMeier, timepoints)
+    map(timepoints) do t
+        idx = searchsortedfirst(km.events.time, t)
+        idx <= length(km.events.natrisk) ? km.events.natrisk[idx] : 0
+    end
+end
+
+# ── Kaplan-Meier transformation ────────────────────────────────────────────
+
+Base.@kwdef struct KaplanMeierAnalysis
+    interval::Union{Symbol,Nothing} = :confidence
+end
+
+function (a::KaplanMeierAnalysis)(input::ProcessedLayer)
+    all_times = reduce(vcat, input.positional[1])
+    global_tmax = maximum(skipmissing(all_times))
+    global_tp, _ = Makie.get_ticks(Makie.automatic, identity, Makie.automatic, 0.0, global_tmax)
+
+    output = AlgebraOfGraphics.map(input) do p, n
+        time, event = p
+        km = fit(KaplanMeier, time, BitVector(event))
+        ci = confint(km)
+
+        t = [0.0; km.events.time]
+        s = [1.0; km.survival]
+        lo = [1.0; [c[1] for c in ci]]
+        hi = [1.0; [c[2] for c in ci]]
+        st, slo, shi = step_band_coords(t, lo, hi)
+        nrisk = risktable_at(km, global_tp)
+
+        return (t, s, st, slo, shi, global_tp, nrisk), (;)
+    end
+
+    ylabel = "Survival Probability"
+
+    function set_ylabel(pl::ProcessedLayer)
+        labels = copy(pl.labels)
+        haskey(labels, 2) ? (labels[2] = ylabel) : insert!(labels, 2, ylabel)
+        ProcessedLayer(pl; labels)
+    end
+
+    stairslayer = set_ylabel(ProcessedLayer(
+        AlgebraOfGraphics.map(output) do p, n
+            t, s, st, slo, shi, tp, nrisk = p
+            (t, s), (;)
+        end;
+        plottype=Stairs, label=:survival,
+        attributes=dictionary([:step => :post]),
+    ))
+
+    zerolayer = set_ylabel(ProcessedLayer(
+        AlgebraOfGraphics.map(output) do p, n
+            t, s, st, slo, shi, tp, nrisk = p
+            ([first(t)], [0.0]), (;)
+        end;
+        plottype=Scatter, label=nothing,
+        attributes=dictionary([:markersize => 0, :legend => (; visible=false)]),
+    ))
+
+    if isnothing(a.interval)
+        return ProcessedLayers([stairslayer, zerolayer])
+    end
+
+    bandlayer = set_ylabel(ProcessedLayer(
+        AlgebraOfGraphics.map(output) do p, n
+            t, s, st, slo, shi, tp, nrisk = p
+            (st, slo, shi), (;)
+        end;
+        plottype=Band, label=:ci,
+        attributes=dictionary([:alpha => 0.3]),
+    ))
+
+    risktable_layer = set_ylabel(ProcessedLayer(
+        AlgebraOfGraphics.map(output) do p, n
+            t, s, st, slo, shi, tp, nrisk = p
+            counts_str = [verbatim(join(string.(nrisk), ",")) for _ in tp]
+            (tp, fill(NaN, length(tp))), (; inspector_label=counts_str)
+        end;
+        plottype=Scatter, label=nothing,
+        attributes=dictionary([:visible => false, :legend => (; visible=false)]),
+    ))
+
+    return ProcessedLayers([bandlayer, stairslayer, risktable_layer, zerolayer])
+end
+
+"""
+    kaplanmeier(; interval=:confidence)
+
+Compute a Kaplan-Meier survival estimate as an AlgebraOfGraphics transformation.
+
+The first positional mapping should be time, the second the event indicator
+(0/1 or Bool).
+
+Use `interval=:confidence` (default) for confidence bands, or
+`interval=nothing` for just the survival curve.
+
+Grouping (e.g. `color=:treatment`) is handled automatically by AlgebraOfGraphics.
+"""
+kaplanmeier(; options...) = transformation(KaplanMeierAnalysis(; options...))
+
+# ── Censor ticks transformation ────────────────────────────────────────────
+
+struct CensorTicksAnalysis end
+
+function (::CensorTicksAnalysis)(input::ProcessedLayer)
+    output = AlgebraOfGraphics.map(input) do p, n
+        time, event = p
+        km = fit(KaplanMeier, time, BitVector(event))
+        cmask = km.events.ncensored .> 0
+        ct = km.events.time[cmask]
+        cs = km.survival[cmask]
+        return (ct, cs), (;)
+    end
+
+    labels = copy(output.labels)
+    haskey(labels, 2) ? (labels[2] = "Survival Probability") : insert!(labels, 2, "Survival Probability")
+
+    return ProcessedLayer(output;
+        plottype=Scatter,
+        labels,
+        attributes=dictionary([:markersize => 8]),
+    )
+end
+
+"""
+    censorticks()
+
+Mark censored observations on a Kaplan-Meier plot. Use as a separate layer
+combined with `kaplanmeier()`:
+
+    plt = data(df) * mapping(:time, :event, color=:group, marker=:group) *
+        (kaplanmeier() + censorticks())
+"""
+censorticks() = transformation(CensorTicksAnalysis())
+
+# ── add_risktable! ──────────────────────────────────────────────────────────
+
+function _extract_strata(ax)
+    strata = Tuple{String,Vector{Float64},Vector{Int},Any}[]
+    for plot in ax.scene.plots
+        if plot isa Scatter && !to_value(plot.visible)
+            pts = to_value(plot[1])
+            tp = [p[1] for p in pts]
+            label_val = to_value(plot.inspector_label)
+            counts_str = label_val isa AbstractVector ? first(label_val) : label_val
+            nrisk = parse.(Int, split(string(counts_str), ","))
+            color = to_value(plot.color)
+            push!(strata, ("", tp, nrisk, color))
+        end
+    end
+    strata
+end
+
+function _legend_color_labels(fig)
+    color_to_label = Dict{Any,String}()
+    for c in fig.content
+        c isa Makie.Legend || continue
+        for (_, entries) in to_value(c.entrygroups)
+            for entry in entries
+                label = to_value(entry.label)
+                for el in entry.elements
+                    if el isa Makie.LineElement
+                        color_to_label[to_value(el.linecolor)] = label
+                    end
+                end
+            end
+        end
+    end
+    color_to_label
+end
+
+"""
+    add_risktable!(fg)
+
+Add a risk table below a Kaplan-Meier plot. Call this on the result
+returned by `draw()`. Works with both single and faceted layouts.
+"""
+function add_risktable!(fg)
+    fig = fg.figure
+    axes = filter(x -> x isa Axis, fig.content)
+    isempty(axes) && return fg
+
+    color_to_label = _legend_color_labels(fig)
+
+    # Determine the grid row below the axes (assume axes are in row 1)
+    ax_row = 2
+
+    for (col_idx, ax) in enumerate(axes)
+        strata = _extract_strata(ax)
+        isempty(strata) && continue
+
+        # Assign group names from legend
+        for (i, (_, tp, nrisk, color)) in enumerate(strata)
+            name = get(color_to_label, color, "")
+            strata[i] = (name, tp, nrisk, color)
+        end
+
+        tp = strata[1][2]
+
+        hidexdecorations!(ax, ticks=false, ticklabels=false, grid=false, minorgrid=false, label=false)
+
+        nrows = length(strata) == 1 ? 2 : 1 + length(strata)
+        show_labels = col_idx == 1
+        row_labels = if length(strata) == 1
+            show_labels ? ["-", "At Risk"] : [" ", " "]
+        else
+            if show_labels
+                vcat([s[1] for s in reverse(strata)], ["At Risk"])
+            else
+                fill(" ", nrows)
+            end
+        end
+
+        tab_ax = Axis(fig[ax_row, col_idx];
+            xlabelvisible=false,
+            height=nrows * 18,
+            yticks=(1:nrows, row_labels),
+            yticklabelsize=10, xticklabelsize=10,
+            ylabelvisible=false,
+            topspinevisible=false, bottomspinevisible=false,
+            leftspinevisible=false, rightspinevisible=false,
+            xgridvisible=false, ygridvisible=false,
+            xticksvisible=false, xticklabelsvisible=false,
+        )
+        linkxaxes!(ax, tab_ax)
+
+        for (j, (label, stp, nrisk, color)) in enumerate(reverse(strata))
+            row = j
+            c = length(strata) == 1 ? :black : color
+            for (k, t) in enumerate(stp)
+                text!(tab_ax, t, row; text=string(nrisk[k]),
+                    align=(:center, :center), fontsize=9, color=c)
+            end
+        end
+
+        ylims!(tab_ax, 0.5, nrows + 0.5)
+    end
+
+    fg
+end
+
+end # module

--- a/src/Survival.jl
+++ b/src/Survival.jl
@@ -23,6 +23,11 @@ export
     fit,
     confint,
 
+    kaplanmeier,
+    censorticks,
+    risktable_at,
+    add_risktable!,
+
     CoxModel,
     coxph,
     coef,
@@ -45,6 +50,12 @@ include("estimator.jl")
 include("kaplanmeier.jl")
 include("nelsonaalen.jl")
 include("cox.jl")
+
+## AlgebraOfGraphics extension stubs (methods added by SurvivalAlgebraOfGraphicsExt)
+function kaplanmeier end
+function censorticks end
+function risktable_at end
+function add_risktable! end
 
 ## Deprecations
 

--- a/src/Survival.jl
+++ b/src/Survival.jl
@@ -25,7 +25,6 @@ export
 
     kaplanmeier,
     censorticks,
-    risktable_at,
     add_risktable!,
 
     CoxModel,
@@ -54,7 +53,6 @@ include("cox.jl")
 ## AlgebraOfGraphics extension stubs (methods added by SurvivalAlgebraOfGraphicsExt)
 function kaplanmeier end
 function censorticks end
-function risktable_at end
 function add_risktable! end
 
 ## Deprecations


### PR DESCRIPTION
## Summary
- Add a package extension (`SurvivalAlgebraOfGraphicsExt`) that provides `kaplanmeier()` and `censorticks()` transformations for AlgebraOfGraphics
- `kaplanmeier()` renders survival curves with confidence bands and risk table data
- `censorticks()` is a separate visual for censor marks, composable via `kaplanmeier() + censorticks()`
- `add_risktable!` adds a number-at-risk table below the plot, with group labels extracted from the legend
- Supports color/marker grouping, column faceting, and `interval=nothing` for curves without CI
- Documentation with examples using the NCCTG lung cancer dataset from RDatasets

## Test plan
- [x] Verify basic KM plot: `data(df) * mapping("time", "event") * kaplanmeier()`
- [x] Verify grouped plot with markers: `mapping(color=...) * (kaplanmeier() + mapping(marker=...) * censorticks())`
- [x] Verify `add_risktable!` shows group names and works with faceted layouts
- [x] Verify `kaplanmeier(interval=nothing)` omits confidence bands
- [x] Verify legend shows correct marker shapes per group