### PR TITLE
Implement Tables column-access interface for EventTable

### DIFF
--- a/src/eventtimes.jl
+++ b/src/eventtimes.jl
@@ -209,9 +209,7 @@ _rowtype(et::EventTable) = _rowtype(typeof(et))
 
 Tables.schema(et::EventTable) = Tables.Schema(_rowtype(et))
 
-function Tables.rows(et::EventTable)
-    NT = _rowtype(et)
-    nr = length(et.time)
-    nc = fieldcount(NT)
-    return (@inbounds(NT(ntuple(i -> getfield(et, i)[j], nc))) for j in 1:nr)
-end
+Tables.columns(et::EventTable) = et
+Tables.columnnames(::EventTable) = fieldnames(EventTable)
+Tables.getcolumn(et::EventTable, i::Int) = getfield(et, i)
+Tables.getcolumn(et::EventTable, nm::Symbol) = getfield(et, nm)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -313,11 +313,21 @@ end
     @test Tables.istable(et)
     @test Tables.columnaccess(et)
     @test Tables.schema(et) isa Tables.Schema{(:time, :nevents, :ncensored, :natrisk),NTuple{4,Int}}
-    @test collect(Tables.rows(et)) == [(; time=1, nevents=0, ncensored=2, natrisk=8),
-                                       (; time=2, nevents=1, ncensored=0, natrisk=6),
-                                       (; time=3, nevents=1, ncensored=1, natrisk=5),
-                                       (; time=4, nevents=0, ncensored=2, natrisk=3),
-                                       (; time=5, nevents=0, ncensored=1, natrisk=1)]
+    @test Tables.rowtable(et) == [(; time=1, nevents=0, ncensored=2, natrisk=8),
+                                  (; time=2, nevents=1, ncensored=0, natrisk=6),
+                                  (; time=3, nevents=1, ncensored=1, natrisk=5),
+                                  (; time=4, nevents=0, ncensored=2, natrisk=3),
+                                  (; time=5, nevents=0, ncensored=1, natrisk=1)]
+    @test Tables.columnnames(et) == (:time, :nevents, :ncensored, :natrisk)
+    @test Tables.getcolumn(et, :time) === et.time
+    @test Tables.getcolumn(et, 2) === et.nevents
+    df = DataFrame(et)
+    @test names(df) == ["time", "nevents", "ncensored", "natrisk"]
+    @test nrow(df) == length(et.time)
+    @test df.time == et.time
+    @test df.nevents == et.nevents
+    @test df.ncensored == et.ncensored
+    @test df.natrisk == et.natrisk
     et2 = copy(et)
     @test et == et2
     @test et !== et2


### PR DESCRIPTION
## Summary
- `EventTable` declares `Tables.columnaccess = true` but never defined `Tables.columns`, `getcolumn`, or `columnnames`, so `DataFrame(et)` and other column-oriented Tables.jl consumers failed. Add those methods (with `EventTable` itself acting as the columns object).
- Drop the custom `Tables.rows` definition. The Tables.jl `RowIterator` fallback yields lazy `ColumnsRow` views with a concretely-typed `eltype`, while the custom generator was eager and reported `eltype = Any`. Update the existing row equality assertion to materialize via `Tables.rowtable`.
- Add `DataFrame(et)` round-trip assertions plus direct `Tables.columnnames`/`getcolumn` checks to the EventTable testset.

## Test plan
- [x] `Pkg.test("Survival")` — all suites pass, EventTable testset goes from 14 to 22 assertions.