### PR TITLE
Update docs to Documenter 1

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -5,7 +5,7 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 Survival = "8a913413-2070-5976-9d4c-2b364fdc2f7f"
 
 [compat]
-Documenter = "~0.27"
+Documenter = "1"
 
 [sources]
 Survival = { path = ".." }

--- a/docs/src/km.md
+++ b/docs/src/km.md
@@ -25,6 +25,7 @@ using Greenwood's formula:
 ```@docs
 Survival.KaplanMeier
 StatsAPI.fit(::Type{KaplanMeier}, ::Any, ::Any)
+StatsAPI.fit(::Type{KaplanMeier}, ::Any)
 StatsAPI.confint(::KaplanMeier)
 ```
 

--- a/docs/src/na.md
+++ b/docs/src/na.md
@@ -25,6 +25,7 @@ from ``n_i`` samples:
 ```@docs
 Survival.NelsonAalen
 StatsAPI.fit(::Type{NelsonAalen}, ::Any, ::Any)
+StatsAPI.fit(::Type{NelsonAalen}, ::Any)
 StatsAPI.confint(::NelsonAalen)
 ```
 


### PR DESCRIPTION
## Summary
- Bump `Documenter` compat in `docs/Project.toml` from `~0.27` to `1`.
- Add the single-argument `fit(::Type{KaplanMeier}, ::Any)` and `fit(::Type{NelsonAalen}, ::Any)` signatures to the API blocks so Documenter 1's stricter `missing_docs` check passes.

## Test plan
- [x] `julia --project=docs docs/make.jl` builds cleanly (only the expected "could not auto-detect the building environment" warning from `deploydocs` when run locally).