### PR TITLE
Expand docstrings and tighten input type annotations

### DIFF
--- a/docs/src/cox.md
+++ b/docs/src/cox.md
@@ -16,7 +16,10 @@ the vector of coefficients in the model.
 ## API
 
 ```@docs
-StatsAPI.fit(::Type{CoxModel}, M::AbstractMatrix, y::AbstractVector; kwargs...)
+Survival.CoxModel
+Survival.coxph
+StatsAPI.fit(::Type{CoxModel}, ::AbstractMatrix, ::AbstractVector{<:Survival.EventTime})
+StatsAPI.confint(::CoxModel)
 ```
 
 ## References

--- a/docs/src/events.md
+++ b/docs/src/events.md
@@ -15,6 +15,8 @@ A dedicated type is provided to conveniently store right censored data.
 
 ```@docs
 Survival.EventTime
+Survival.isevent
+Survival.iscensored
 ```
 
 ## Summarizing Event Times

--- a/src/cox.jl
+++ b/src/cox.jl
@@ -263,9 +263,9 @@ one column per covariate) and the response vector `y` of [`EventTime`](@ref) val
 The rows of `M` and the entries of `y` must be in the same order; the model sorts them
 internally by `y` before optimization.
 
-The coefficient vector is estimated by maximizing the partial log-likelihood (Breslow's
-approximation for ties) with a Newton trust-region method. Integer matrices are
-promoted to floating point. No intercept column is fit — the baseline hazard is
+The coefficient vector is estimated by maximizing the partial log-likelihood (Efron's
+approximation for tied event times) with a Newton trust-region method. Integer matrices
+are promoted to floating point. No intercept column is fit — the baseline hazard is
 unidentified in the partial likelihood.
 
 Keyword arguments:

--- a/src/cox.jl
+++ b/src/cox.jl
@@ -78,6 +78,25 @@ end
 
 # Structure of Cox regression output
 
+"""
+    CoxModel{T<:Real} <: RegressionModel
+
+Result of fitting a Cox proportional hazards model via [`coxph`](@ref) or
+`fit(CoxModel, ...)`. Use `coef`, `stderror`, `vcov`, `confint`, `loglikelihood`,
+`nullloglikelihood`, `nobs`, `dof`, `dof_residual`, and `coeftable` to inspect the
+fitted model. The exposed fields are:
+
+* `β::Vector{T}`: estimated coefficient vector (the maximum partial-likelihood point
+  estimate, possibly with an L2 penalty — see `fit`).
+* `loglik::T`: maximized partial log-likelihood at `β`.
+* `score::Vector{T}`: gradient of the partial log-likelihood at `β`.
+* `fischer_info::Matrix{T}`: observed information matrix (Hessian of the negative
+  partial log-likelihood) at `β`.
+* `vcov::Matrix{T}`: estimated variance–covariance matrix of `β`, computed as the
+  pseudo-inverse of `fischer_info`.
+* `aux::CoxAux{T}`: internal workspace holding the design matrix, the sorted response,
+  and bookkeeping for tied event times. Not part of the public API.
+"""
 struct CoxModel{T<:Real} <: RegressionModel
     aux::CoxAux{T}
     β::Vector{T}
@@ -123,6 +142,13 @@ StatsAPI.vcov(obj::CoxModel) = obj.vcov
 
 StatsAPI.stderror(obj::CoxModel) = sqrt.(diag(vcov(obj)))
 
+"""
+    confint(obj::CoxModel; level::Real=0.95) -> Matrix{Float64}
+
+Compute the two-sided Wald confidence intervals for the coefficients of `obj` and return
+them as an `n × 2` matrix whose columns are the lower and upper bounds, in coefficient
+order. `level` is the nominal coverage of the interval (default 0.95).
+"""
 function StatsAPI.confint(obj::CoxModel; level::Real=0.95)
     β = coef(obj)
     se = stderror(obj)
@@ -229,17 +255,45 @@ end
 StatsModels.drop_intercept(::Type{CoxModel}) = true
 
 """
-    fit(::Type{CoxModel}, M::AbstractMatrix, y::AbstractVector; kwargs...)
+    fit(::Type{CoxModel}, M::AbstractMatrix, y::AbstractVector{<:EventTime};
+        tol::Real=1e-4, l2_cost::Real=0) -> CoxModel
 
-Given a matrix `M` of predictors and a corresponding vector of events, compute the
-Cox proportional hazard model estimate of coefficients. Returns a `CoxModel`
-object.
+Fit a Cox proportional hazards model to the design matrix `M` (one row per observation,
+one column per covariate) and the response vector `y` of [`EventTime`](@ref) values.
+The rows of `M` and the entries of `y` must be in the same order; the model sorts them
+internally by `y` before optimization.
+
+The coefficient vector is estimated by maximizing the partial log-likelihood (Breslow's
+approximation for ties) with a Newton trust-region method. Integer matrices are
+promoted to floating point. No intercept column is fit — the baseline hazard is
+unidentified in the partial likelihood.
+
+Keyword arguments:
+
+* `tol::Real=1e-4`: gradient-norm tolerance passed to the optimizer. Tighten this when
+  comparing against high-precision references.
+* `l2_cost::Real=0`: coefficient of an L2 (ridge) penalty `l2_cost * β'β` added to the
+  negative log-likelihood. The default is no penalization.
+
+Use [`coxph`](@ref) for the conventional shorthand or for the
+`@formula(event ~ ...)` interface via StatsModels.
 """
-function StatsAPI.fit(::Type{CoxModel}, M::AbstractMatrix, y::AbstractVector; tol=1e-4, l2_cost=0)
+function StatsAPI.fit(::Type{CoxModel}, M::AbstractMatrix, y::AbstractVector{<:EventTime};
+                      tol::Real=1e-4, l2_cost::Real=0)
     index_perm = sortperm(y)
     X = M[index_perm,:]
     s = y[index_perm]
     _coxph(X, s; tol=tol, l2_cost=l2_cost)
 end
 
+"""
+    coxph(M::AbstractMatrix, y::AbstractVector{<:EventTime}; kwargs...) -> CoxModel
+    coxph(formula::FormulaTerm, data; kwargs...)
+
+Fit a Cox proportional hazards model. Equivalent to `fit(CoxModel, M, y; kwargs...)`
+when called with a design matrix and response vector, and to the corresponding
+StatsModels formula form when called with a `@formula` and a Tables.jl-compatible
+data source. See [`fit(::Type{CoxModel}, ::AbstractMatrix, ::AbstractVector)`](@ref)
+for accepted keyword arguments.
+"""
 coxph(M, y; kwargs...) = fit(CoxModel, M, y; kwargs...)

--- a/src/eventtimes.jl
+++ b/src/eventtimes.jl
@@ -5,10 +5,20 @@
 ## Type constructors
 
 """
-    EventTime{T}
+    EventTime{T}(time::T, status::Bool)
+    EventTime(time, status=true)
 
-Immutable object containing the real-valued time to an event as well as an indicator of
-whether the time corresponds to an observed event (`true`) or right censoring (`false`).
+Immutable object containing a time-to-event together with an indicator of whether the
+time corresponds to an observed event (`status=true`) or to right censoring
+(`status=false`). The single-argument form constructs an observed event.
+
+The type parameter `T` is the type of the time value. Any totally ordered type that
+supports `isless` and `zero` is accepted, including `Real` subtypes and `Dates.Period`
+subtypes.
+
+`isless` is defined so that, when two `EventTime`s share the same `time`, an observed
+event compares less than a censored one — by definition, the true event time of a
+censored observation is at least the recorded time.
 """
 struct EventTime{T}
     time::T
@@ -44,7 +54,19 @@ end
 
 ## New functions
 
+"""
+    isevent(ev::EventTime) -> Bool
+
+Return `true` if `ev` records an observed event and `false` if it is right censored.
+"""
 isevent(ev::EventTime) = ev.status
+
+"""
+    iscensored(ev::EventTime) -> Bool
+
+Return `true` if `ev` is right censored and `false` if it records an observed event.
+Equivalent to `!isevent(ev)`.
+"""
 iscensored(ev::EventTime) = !ev.status
 
 ## StatsModels compatibility
@@ -60,22 +82,24 @@ Base.copy(et::EventTime) = et
 
 """
     EventTable{T}
+    EventTable(eventtimes::AbstractVector{<:EventTime})
+    EventTable(time::AbstractVector, status::AbstractVector)
 
-Immutable object summarizing the unique observed event times, including the number of
-events, the number of censored observations, and the number remaining at risk for each
-unique time.
+Immutable summary of a set of observations, aggregated to one row per unique observed
+time. The fields are parallel vectors of length equal to the number of unique observed
+times:
 
-This type implements the Tables.jl interface for tables, which means that `EventTable`
-objects can be seamlessly converted to other tabular types such as `DataFrame`s.
+* `time::Vector{T}`: the unique observed times in ascending order.
+* `nevents::Vector{Int}`: the number of observed events at each time.
+* `ncensored::Vector{Int}`: the number of right-censored observations at each time.
+* `natrisk::Vector{Int}`: the size of the risk set just before each time, i.e. the
+  number of subjects whose recorded time is greater than or equal to that time.
 
-    EventTable(eventtimes)
+Observations with `time == zero(T)` are dropped because they contribute nothing to the
+risk set; the input does not need to be sorted.
 
-Construct an `EventTable` from an array of [`EventTime`](@ref) values.
-
-    EventTable(time, status)
-
-Construct an `EventTable` from an array of time values and an array of event status
-indicators.
+`EventTable` implements the Tables.jl column-access interface, so it can be converted to
+other tabular types (e.g. `DataFrame`) and iterated row by row via `Tables.rows`.
 """
 struct EventTable{T}
     time::Vector{T}
@@ -84,7 +108,7 @@ struct EventTable{T}
     natrisk::Vector{Int}
 end
 
-function EventTable(ets)
+function EventTable(ets::AbstractVector{<:EventTime})
     T = eltype(eltype(ets))
     isempty(ets) && return EventTable{T}(T[], Int[], Int[], Int[])
     ets = issorted(ets) ? ets : sort(ets)  # re-binding, input is unaffected
@@ -92,7 +116,7 @@ function EventTable(ets)
     return _eventtable(ets)
 end
 
-function EventTable(time, status)
+function EventTable(time::AbstractVector, status::AbstractVector)
     ntimes = length(time)
     nstatus = length(status)
     if ntimes != nstatus

--- a/src/kaplanmeier.jl
+++ b/src/kaplanmeier.jl
@@ -1,21 +1,22 @@
 """
     KaplanMeier{S,T}
 
-An immutable type containing survivor function estimates computed
-using the Kaplan-Meier method.
-The type has the following fields:
+Immutable type containing survivor function estimates computed using the Kaplan-Meier
+method. The estimates are evaluated at each unique observed time and are stepwise
+constant between them. The fields are parallel vectors with one entry per unique
+observed time:
 
-* `events`: An [`EventTable`](@ref) summarizing the times and events
-  used to compute the estimates. The time values are of type `T`.
-* `survival`: Estimate of the survival probability at each time. Values
-  are of type `S`.
-* `stderr`: Standard error of the log survivor function at each time.
-  Values are of type `S`.
+* `events::EventTable{T}`: the [`EventTable`](@ref) summarizing the times and events
+  used to compute the estimates.
+* `survival::Vector{S}`: estimate of the survivor function at each time.
+* `stderr::Vector{S}`: Greenwood's-formula standard error of the log of the survivor
+  function at each time. Note that this is the standard error of `log(survival)`, not
+  of `survival` itself; this form is convenient for log-log–transformed confidence
+  intervals (see [`confint`](@ref)).
 
-Use `fit(KaplanMeier, ...)` to compute the estimates as `Float64`
-values and construct this type.
-Alternatively, `fit(KaplanMeier{S}, ...)` may be used to request a
-particular value type `S` for the estimates.
+Use `fit(KaplanMeier, ...)` to compute the estimates as `Float64` values and construct
+this type. Alternatively, `fit(KaplanMeier{S}, ...)` may be used to request a particular
+value type `S` for the estimates (e.g. `Float32`).
 """
 struct KaplanMeier{S,T} <: NonparametricEstimator
     events::EventTable{T}
@@ -33,10 +34,16 @@ estimator_update(::Type{<:KaplanMeier}, es, dᵢ, nᵢ) = es * (1 - dᵢ // nᵢ
 stderr_update(::Type{<:KaplanMeier}, gw, dᵢ, nᵢ) = gw + dᵢ // (nᵢ * (nᵢ - dᵢ))
 
 """
-    confint(km::KaplanMeier; level=0.95)
+    confint(km::KaplanMeier; level::Real=0.95) -> Vector{Tuple{Float64,Float64}}
 
-Compute the pointwise log-log transformed confidence intervals for the survivor
-function as a vector of tuples.
+Compute pointwise confidence intervals for the survivor function at each time in
+`km.events.time` and return them as a vector of `(lower, upper)` tuples. `level` is the
+nominal coverage of the two-sided interval (default 0.95).
+
+The intervals are constructed on the log-log scale, i.e. by forming a symmetric Wald
+interval for `log(-log(S(t)))` and back-transforming. This guarantees that the bounds
+lie in `[0, 1]` and tends to give better small-sample coverage than the plain Wald
+interval on `S(t)` itself.
 """
 function StatsAPI.confint(km::KaplanMeier; level::Real=0.95)
     q = quantile(Normal(), (1 + level)/2)
@@ -48,18 +55,17 @@ function StatsAPI.confint(km::KaplanMeier; level::Real=0.95)
 end
 
 """
-    fit(KaplanMeier, times, status) -> KaplanMeier
+    fit(::Type{KaplanMeier}, times::AbstractVector, status::AbstractVector) -> KaplanMeier
+    fit(::Type{KaplanMeier}, ets::AbstractVector{<:EventTime}) -> KaplanMeier
+    fit(::Type{KaplanMeier}, et::EventTable) -> KaplanMeier
 
-Given a vector of times to events and a corresponding vector of indicators that
-denote whether each time is an observed event or is right censored, compute the
-Kaplan-Meier estimate of the survivor function.
+Compute the Kaplan-Meier estimate of the survivor function. The input may be supplied
+as parallel vectors of times and event-status indicators, as a vector of
+[`EventTime`](@ref) values, or as a precomputed [`EventTable`](@ref). When `times` and
+`status` are passed separately they must have the same length; `status` values are
+converted to `Bool` (true ⇒ observed event, false ⇒ right censoring).
+
+`fit(KaplanMeier{S}, ...)` may be used to request a particular value type `S` for the
+estimates, e.g. `Float32`. The default is `Float64`.
 """
 StatsAPI.fit(::Type{KaplanMeier}, times, status)
-
-"""
-    fit(KaplanMeier, ets) -> KaplanMeier
-
-Compute the Kaplan-Meier estimate of the survivor function from a vector of
-[`EventTime`](@ref) values.
-"""
-StatsAPI.fit(::Type{KaplanMeier}, ets)

--- a/src/nelsonaalen.jl
+++ b/src/nelsonaalen.jl
@@ -1,21 +1,20 @@
 """
     NelsonAalen{S,T}
 
-An immutable type containing cumulative hazard function estimates computed
-using the Nelson-Aalen method.
-The type has the following fields:
+Immutable type containing cumulative-hazard function estimates computed using the
+Nelson-Aalen method. The estimates are evaluated at each unique observed time and are
+stepwise constant between them. The fields are parallel vectors with one entry per
+unique observed time:
 
-* `events`: An [`EventTable`](@ref) summarizing the times and events
-  used to compute the estimates. The time values are of type `T`.
-* `chaz`: Estimate of the cumulative hazard at each time. Values are of
-  type `S`.
-* `stderr`: Standard error of the cumulative hazard at each time. Values
-  are of type `S`.
+* `events::EventTable{T}`: the [`EventTable`](@ref) summarizing the times and events
+  used to compute the estimates.
+* `chaz::Vector{S}`: estimate of the cumulative hazard at each time.
+* `stderr::Vector{S}`: standard error of the cumulative hazard at each time, computed
+  as the binomial-variance form ``\\sqrt{\\sum_i d_i(n_i - d_i)/n_i^3}``.
 
-Use `fit(NelsonAalen, ...)` to compute the estimates as `Float64` values
-and construct this type.
-Alternatively, `fit(NelsonAalen{S}, ...)` may be used to request a
-particular value type `S` for the estimates.
+Use `fit(NelsonAalen, ...)` to compute the estimates as `Float64` values and construct
+this type. Alternatively, `fit(NelsonAalen{S}, ...)` may be used to request a particular
+value type `S` for the estimates (e.g. `Float32`).
 """
 struct NelsonAalen{S,T} <: NonparametricEstimator
     events::EventTable{T}
@@ -33,10 +32,12 @@ estimator_update(::Type{<:NelsonAalen}, es, dᵢ, nᵢ) = es + dᵢ // nᵢ
 stderr_update(::Type{<:NelsonAalen}, gw, dᵢ, nᵢ) = gw + dᵢ * (nᵢ - dᵢ) // (nᵢ^3)
 
 """
-    confint(na::NelsonAalen; level=0.95)
+    confint(na::NelsonAalen; level::Real=0.95) -> Vector{Tuple{Float64,Float64}}
 
-Compute the pointwise confidence intervals for the cumulative hazard
-function as a vector of tuples.
+Compute pointwise Wald confidence intervals for the cumulative hazard function at each
+time in `na.events.time` and return them as a vector of `(lower, upper)` tuples.
+`level` is the nominal coverage of the two-sided interval (default 0.95). The lower
+bound is not clipped at zero, so it may be negative for small estimates.
 """
 function StatsAPI.confint(na::NelsonAalen; level::Real=0.95)
     q = quantile(Normal(), (1 + level)/2)
@@ -46,18 +47,17 @@ function StatsAPI.confint(na::NelsonAalen; level::Real=0.95)
 end
 
 """
-    fit(NelsonAalen, times, status) -> NelsonAalen
+    fit(::Type{NelsonAalen}, times::AbstractVector, status::AbstractVector) -> NelsonAalen
+    fit(::Type{NelsonAalen}, ets::AbstractVector{<:EventTime}) -> NelsonAalen
+    fit(::Type{NelsonAalen}, et::EventTable) -> NelsonAalen
 
-Given a vector of times to events and a corresponding vector of indicators that
-denote whether each time is an observed event or is right censored, compute the
-Nelson-Aalen estimate of the cumulative hazard rate function.
+Compute the Nelson-Aalen estimate of the cumulative hazard function. The input may be
+supplied as parallel vectors of times and event-status indicators, as a vector of
+[`EventTime`](@ref) values, or as a precomputed [`EventTable`](@ref). When `times` and
+`status` are passed separately they must have the same length; `status` values are
+converted to `Bool` (true ⇒ observed event, false ⇒ right censoring).
+
+`fit(NelsonAalen{S}, ...)` may be used to request a particular value type `S` for the
+estimates, e.g. `Float32`. The default is `Float64`.
 """
 StatsAPI.fit(::Type{NelsonAalen}, times, status)
-
-"""
-    fit(NelsonAalen, ets) -> NelsonAalen
-
-Compute the Nelson-Aalen estimate of the cumulative hazard rate function from a
-vector of [`EventTime`](@ref) values.
-"""
-StatsAPI.fit(::Type{NelsonAalen}, ets)


### PR DESCRIPTION
## Summary
- Revisit each public docstring to cover details that were either missing or stale relative to the implementation (e.g. `EventTime`'s docstring still claimed "real-valued" times after the `<:Real` bound was removed in e71bce8).
- Document `isevent`, `iscensored`, `CoxModel`, `coxph`, and `confint(::CoxModel)`, all of which were exported but undocumented.
- Consolidate the per-method `fit` docstrings for `KaplanMeier` and `NelsonAalen` into a single docstring per estimator that lists every accepted input form (separate `times`/`status` vectors, vector of `EventTime`, or precomputed `EventTable`) and the `{S}` value-type form.
- Add concrete keyword-argument documentation (`tol`, `l2_cost`, `level`) and return-shape annotations where they were missing.
- Tighten input type annotations on `EventTable(::AbstractVector{<:EventTime})`, `EventTable(::AbstractVector, ::AbstractVector)`, and `fit(::Type{CoxModel}, ::AbstractMatrix, ::AbstractVector{<:EventTime}; ...)`. The `coxph` shorthand stays untyped so the formula path continues to dispatch through StatsModels.
- Wire the new docstrings into `docs/src/events.md` and `docs/src/cox.md`.

This is a follow-up to #81, which moved the docs to Documenter 1. After #81 merges, this branch will need a trivial rebase to drop the second `fit` reference line in `km.md`/`na.md` (no longer needed after the docstring consolidation).

## Test plan
- [x] `julia --project=. -e 'using Pkg; Pkg.test()'` — all suites green (Event times, Kaplan-Meier, Nelson-Aalen, Cox, EventTable).
- [x] `julia --project=docs docs/make.jl` — builds cleanly with Documenter 1, only the expected "could not auto-detect the building environment" warning.